### PR TITLE
feat: add JSON-first Alkalye CLI for agent auth + docs CRUD

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,8 @@
         "astro": "^5.16.15",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cojson": "^0.20.4",
+        "cojson-transport-ws": "^0.20.4",
         "dompurify": "^3.3.1",
         "fast-myers-diff": "^3.2.0",
         "idb-keyval": "^6.2.2",
@@ -1130,7 +1132,7 @@
 
     "code-block-writer": ["code-block-writer@13.0.3", "", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
 
-    "cojson": ["cojson@0.14.28", "", { "dependencies": { "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.1", "@noble/hashes": "^1.8.0", "@opentelemetry/api": "^1.9.0", "@scure/base": "1.2.1", "jazz-crypto-rs": "0.0.7", "neverthrow": "^7.0.1", "queueueue": "^4.1.2", "unicode-segmenter": "^0.12.0" } }, "sha512-aIp4/66KHG5/E/mTrpIB5w3iYklweKOK/d4phKOMndAQy+UawvaZqvEmUteQ8XbTDNp7KZZD5g4p0uIy8BAi8A=="],
+    "cojson": ["cojson@0.20.4", "", { "dependencies": { "@noble/hashes": "^1.8.0", "@opentelemetry/api": "^1.9.0", "@scure/base": "1.2.1", "cojson-core-napi": "0.20.4", "cojson-core-rn": "0.20.4", "cojson-core-wasm": "0.20.4", "unicode-segmenter": "^0.12.0" } }, "sha512-rMEihUacQQ4osJUi7WIOTniVo5Nbhf9Aj/hovhu13rAaDApzYFfVJqpJXcCpFwsMWi3IhYyRc5RTI7YGoJCRTA=="],
 
     "cojson-core-napi": ["cojson-core-napi@0.20.4", "", { "optionalDependencies": { "cojson-core-napi-darwin-arm64": "0.20.4", "cojson-core-napi-darwin-x64": "0.20.4", "cojson-core-napi-linux-arm-gnueabihf": "0.20.4", "cojson-core-napi-linux-arm64-gnu": "0.20.4", "cojson-core-napi-linux-arm64-musl": "0.20.4", "cojson-core-napi-linux-x64-gnu": "0.20.4", "cojson-core-napi-linux-x64-musl": "0.20.4" } }, "sha512-ldI/t3zlqQ92n+FMjkhx5N4nT9x83zTNsoXxaBTQpB1+pVtjXlArlhMlaZLJmjR+cZdt8cTKfAmtd2aI+V0zUQ=="],
 
@@ -1156,7 +1158,7 @@
 
     "cojson-storage-indexeddb": ["cojson-storage-indexeddb@0.20.4", "", { "dependencies": { "cojson": "0.20.4" } }, "sha512-uyTKhpN4TkBqVqD8qZz/MgMkcZ2vHcdY1EFqaCkV4Y8MP39hJTfP+XYJTGDqzi9YC+ZQArJU0ks8HgUYKLk14w=="],
 
-    "cojson-transport-ws": ["cojson-transport-ws@0.14.28", "", { "dependencies": { "cojson": "0.14.28" } }, "sha512-VUa3X8OltO0dqXmps4+KOJvdwJ2ztzr+Aiin9wsBcWEiK7K5r7ae/hEwqjnrOS/8jOX/C0V2jBdx645nGwBQRA=="],
+    "cojson-transport-ws": ["cojson-transport-ws@0.20.4", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "cojson": "0.20.4" } }, "sha512-FhucYIgvx/QTUKbAqphqGopGfxU4Ecsf1OmgFvSTBh2lChbFNYtF6GzXEvyuWMhOEcuhpsmjiF1vhYSC7yUbGw=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -2822,7 +2824,7 @@
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
-    "cojson-storage-indexeddb/cojson": ["cojson@0.20.4", "", { "dependencies": { "@noble/hashes": "^1.8.0", "@opentelemetry/api": "^1.9.0", "@scure/base": "1.2.1", "cojson-core-napi": "0.20.4", "cojson-core-rn": "0.20.4", "cojson-core-wasm": "0.20.4", "unicode-segmenter": "^0.12.0" } }, "sha512-rMEihUacQQ4osJUi7WIOTniVo5Nbhf9Aj/hovhu13rAaDApzYFfVJqpJXcCpFwsMWi3IhYyRc5RTI7YGoJCRTA=="],
+    "cojson-storage/cojson": ["cojson@0.14.28", "", { "dependencies": { "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.1", "@noble/hashes": "^1.8.0", "@opentelemetry/api": "^1.9.0", "@scure/base": "1.2.1", "jazz-crypto-rs": "0.0.7", "neverthrow": "^7.0.1", "queueueue": "^4.1.2", "unicode-segmenter": "^0.12.0" } }, "sha512-aIp4/66KHG5/E/mTrpIB5w3iYklweKOK/d4phKOMndAQy+UawvaZqvEmUteQ8XbTDNp7KZZD5g4p0uIy8BAi8A=="],
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
@@ -2850,19 +2852,25 @@
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
+    "jazz-browser/cojson": ["cojson@0.14.28", "", { "dependencies": { "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.1", "@noble/hashes": "^1.8.0", "@opentelemetry/api": "^1.9.0", "@scure/base": "1.2.1", "jazz-crypto-rs": "0.0.7", "neverthrow": "^7.0.1", "queueueue": "^4.1.2", "unicode-segmenter": "^0.12.0" } }, "sha512-aIp4/66KHG5/E/mTrpIB5w3iYklweKOK/d4phKOMndAQy+UawvaZqvEmUteQ8XbTDNp7KZZD5g4p0uIy8BAi8A=="],
+
     "jazz-browser/cojson-storage-indexeddb": ["cojson-storage-indexeddb@0.14.28", "", { "dependencies": { "cojson": "0.14.28", "cojson-storage": "0.14.28" } }, "sha512-FHVEHU2JyN9v8Yu2VCq89+OuyzrXf+4yTx+bJLfP2Fy2Wihhiq/Q8Wko6WIsmhMB1NfSZ7TthymUPK6Y3ibEog=="],
+
+    "jazz-browser/cojson-transport-ws": ["cojson-transport-ws@0.14.28", "", { "dependencies": { "cojson": "0.14.28" } }, "sha512-VUa3X8OltO0dqXmps4+KOJvdwJ2ztzr+Aiin9wsBcWEiK7K5r7ae/hEwqjnrOS/8jOX/C0V2jBdx645nGwBQRA=="],
 
     "jazz-browser/jazz-tools": ["jazz-tools@0.14.28", "", { "dependencies": { "@scure/bip39": "^1.3.0", "cojson": "0.14.28", "fast-myers-diff": "^3.2.0", "zod": "3.25.28" } }, "sha512-T6HGV2zzDkITAfy5B/VcDbWyS9aZxihtqDVg5erU1VxfpH6SR0GKI9mTG+odCZ2zJVfzQDoanEY0StDmWNA5Ag=="],
 
     "jazz-browser-media-images/jazz-tools": ["jazz-tools@0.14.28", "", { "dependencies": { "@scure/bip39": "^1.3.0", "cojson": "0.14.28", "fast-myers-diff": "^3.2.0", "zod": "3.25.28" } }, "sha512-T6HGV2zzDkITAfy5B/VcDbWyS9aZxihtqDVg5erU1VxfpH6SR0GKI9mTG+odCZ2zJVfzQDoanEY0StDmWNA5Ag=="],
 
+    "jazz-react/cojson": ["cojson@0.14.28", "", { "dependencies": { "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.1", "@noble/hashes": "^1.8.0", "@opentelemetry/api": "^1.9.0", "@scure/base": "1.2.1", "jazz-crypto-rs": "0.0.7", "neverthrow": "^7.0.1", "queueueue": "^4.1.2", "unicode-segmenter": "^0.12.0" } }, "sha512-aIp4/66KHG5/E/mTrpIB5w3iYklweKOK/d4phKOMndAQy+UawvaZqvEmUteQ8XbTDNp7KZZD5g4p0uIy8BAi8A=="],
+
+    "jazz-react/cojson-transport-ws": ["cojson-transport-ws@0.14.28", "", { "dependencies": { "cojson": "0.14.28" } }, "sha512-VUa3X8OltO0dqXmps4+KOJvdwJ2ztzr+Aiin9wsBcWEiK7K5r7ae/hEwqjnrOS/8jOX/C0V2jBdx645nGwBQRA=="],
+
     "jazz-react/jazz-tools": ["jazz-tools@0.14.28", "", { "dependencies": { "@scure/bip39": "^1.3.0", "cojson": "0.14.28", "fast-myers-diff": "^3.2.0", "zod": "3.25.28" } }, "sha512-T6HGV2zzDkITAfy5B/VcDbWyS9aZxihtqDVg5erU1VxfpH6SR0GKI9mTG+odCZ2zJVfzQDoanEY0StDmWNA5Ag=="],
 
+    "jazz-react-core/cojson": ["cojson@0.14.28", "", { "dependencies": { "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.1", "@noble/hashes": "^1.8.0", "@opentelemetry/api": "^1.9.0", "@scure/base": "1.2.1", "jazz-crypto-rs": "0.0.7", "neverthrow": "^7.0.1", "queueueue": "^4.1.2", "unicode-segmenter": "^0.12.0" } }, "sha512-aIp4/66KHG5/E/mTrpIB5w3iYklweKOK/d4phKOMndAQy+UawvaZqvEmUteQ8XbTDNp7KZZD5g4p0uIy8BAi8A=="],
+
     "jazz-react-core/jazz-tools": ["jazz-tools@0.14.28", "", { "dependencies": { "@scure/bip39": "^1.3.0", "cojson": "0.14.28", "fast-myers-diff": "^3.2.0", "zod": "3.25.28" } }, "sha512-T6HGV2zzDkITAfy5B/VcDbWyS9aZxihtqDVg5erU1VxfpH6SR0GKI9mTG+odCZ2zJVfzQDoanEY0StDmWNA5Ag=="],
-
-    "jazz-tools/cojson": ["cojson@0.20.4", "", { "dependencies": { "@noble/hashes": "^1.8.0", "@opentelemetry/api": "^1.9.0", "@scure/base": "1.2.1", "cojson-core-napi": "0.20.4", "cojson-core-rn": "0.20.4", "cojson-core-wasm": "0.20.4", "unicode-segmenter": "^0.12.0" } }, "sha512-rMEihUacQQ4osJUi7WIOTniVo5Nbhf9Aj/hovhu13rAaDApzYFfVJqpJXcCpFwsMWi3IhYyRc5RTI7YGoJCRTA=="],
-
-    "jazz-tools/cojson-transport-ws": ["cojson-transport-ws@0.20.4", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "cojson": "0.20.4" } }, "sha512-FhucYIgvx/QTUKbAqphqGopGfxU4Ecsf1OmgFvSTBh2lChbFNYtF6GzXEvyuWMhOEcuhpsmjiF1vhYSC7yUbGw=="],
 
     "jazz-tools/zod": ["zod@4.1.11", "", {}, "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg=="],
 
@@ -3085,6 +3093,8 @@
     "hast-util-from-html/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "hast-util-raw/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "jazz-browser-media-images/jazz-tools/cojson": ["cojson@0.14.28", "", { "dependencies": { "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.1", "@noble/hashes": "^1.8.0", "@opentelemetry/api": "^1.9.0", "@scure/base": "1.2.1", "jazz-crypto-rs": "0.0.7", "neverthrow": "^7.0.1", "queueueue": "^4.1.2", "unicode-segmenter": "^0.12.0" } }, "sha512-aIp4/66KHG5/E/mTrpIB5w3iYklweKOK/d4phKOMndAQy+UawvaZqvEmUteQ8XbTDNp7KZZD5g4p0uIy8BAi8A=="],
 
     "jazz-browser-media-images/jazz-tools/zod": ["zod@3.25.28", "", {}, "sha512-/nt/67WYKnr5by3YS7LroZJbtcCBurDKKPBPWWzaxvVCGuG/NOsiKkrjoOhI8mJ+SQUXEbUzeB3S+6XDUEEj7Q=="],
 

--- a/docs/cli-agent.md
+++ b/docs/cli-agent.md
@@ -25,15 +25,21 @@ For any docs command, provide one of:
 
 ## Auth commands
 
-- `auth sign-in` (derives session credentials from passphrase)
-- `auth create-account` (prepares deterministic account credentials from passphrase)
+- `auth sign-in` (derives session credentials from passphrase and optionally persists via `--session-file`)
+- `auth create-account` (creates account on sync server for passphrase-derived credentials; supports `--session-file` persistence)
 - `auth status`
 - `auth sign-out`
 
 Example:
 
 ```bash
-bun run cli -- auth sign-in --passphrase-env ALK_PASS > /tmp/alk-session.json
+bun run cli -- auth sign-in --passphrase-env ALK_PASS --session-file /tmp/alk-session.json
+```
+
+Local smoke test (idempotent, creates a temporary space when `ALK_TEST_SPACE_ID` is unset):
+
+```bash
+ALK_SYNC_URL=ws://127.0.0.1:4200 bun run test:cli:smoke
 ```
 
 ## Docs commands

--- a/docs/cli-agent.md
+++ b/docs/cli-agent.md
@@ -1,0 +1,88 @@
+# Alkalye Agent CLI Prototype
+
+This prototype CLI provides machine-readable JSON output for agent workflows.
+
+## Run
+
+```bash
+bun run cli -- auth status
+```
+
+`stdout` always contains one JSON object:
+
+- success
+
+```json
+{"ok":true,"command":"auth.status","data":{}}
+```
+
+- failure
+
+```json
+{"ok":false,"command":"docs.create","error":{"code":"missing_required_option","message":"Missing required option --space-id"}}
+```
+
+## Global flags
+
+- `--base-url <url>`: backend base URL (default `https://www.alkalye.com/api/agent/v1`)
+- `--timeout <ms>`: request timeout in milliseconds
+- `--headless` / `--no-headless`: sets `x-alk-headless` request header
+
+## Auth commands
+
+- `auth sign-in`
+- `auth sign-out`
+- `auth status`
+- `auth create-account`
+
+Passphrase sources:
+
+- `--passphrase "word1 word2 ..."`
+- `--passphrase-env ALK_PASS`
+- `--passphrase-file /secure/path/passphrase.txt`
+- `--passphrase-stdin`
+
+Examples:
+
+```bash
+bun run cli -- auth sign-in --passphrase-env ALK_PASS
+printf 'word1 word2 word3' | bun run cli -- auth sign-in --passphrase-stdin
+bun run cli -- auth create-account --name "Agent Writer" --passphrase-file /tmp/passphrase.txt
+```
+
+If backend create-account is unavailable, CLI returns:
+
+```json
+{"ok":false,"command":"auth.create-account","error":{"code":"not_supported","message":"Operation not supported by backend"}}
+```
+
+## Docs commands
+
+- `docs create --space-id <id> --title <title> --content <content>`
+- `docs read --doc-id <id>`
+- `docs update --doc-id <id> --content <content> [--append|--replace]`
+- `docs list --space-id <id> [--query <text>]`
+- `docs search --space-id <id> [--query <text>]`
+- `docs delete --doc-id <id> [--soft-delete|--hard-delete]`
+- `docs upsert --space-id <id> --title <title> --content <content>`
+
+Upsert behavior:
+
+1. list/search docs in the space by title
+2. update exact title match if found
+3. create if no exact title match exists
+
+Examples:
+
+```bash
+bun run cli -- docs create --space-id sp_123 --title "Spec" --content "v1"
+bun run cli -- docs update --doc-id doc_123 --append --content "\nnew note"
+bun run cli -- docs list --space-id sp_123 --query roadmap
+bun run cli -- docs upsert --space-id sp_123 --title "Roadmap" --content "Q2 plan"
+```
+
+## Safety notes
+
+- Prefer env/file/stdin passphrase sources over shell history.
+- `--hard-delete` requests permanent delete and may be irreversible.
+- Non-2xx HTTP responses are mapped into JSON errors with status/details when available.

--- a/docs/cli-agent.md
+++ b/docs/cli-agent.md
@@ -1,59 +1,39 @@
-# Alkalye Agent CLI Prototype
+# Alkalye Jazz CLI
 
-This prototype CLI provides machine-readable JSON output for agent workflows.
+CLI now talks to the Jazz sync endpoint directly (no `/api/agent/v1`).
 
 ## Run
 
 ```bash
-bun run cli -- auth status
+bun run cli -- auth sign-in --passphrase-env ALK_PASS
 ```
 
-`stdout` always contains one JSON object:
-
-- success
-
-```json
-{"ok":true,"command":"auth.status","data":{}}
-```
-
-- failure
-
-```json
-{"ok":false,"command":"docs.create","error":{"code":"missing_required_option","message":"Missing required option --space-id"}}
-```
+Outputs one JSON object on stdout.
 
 ## Global flags
 
-- `--base-url <url>`: backend base URL (default `https://www.alkalye.com/api/agent/v1`)
-- `--timeout <ms>`: request timeout in milliseconds
-- `--headless` / `--no-headless`: sets `x-alk-headless` request header
+- `--sync-url <wss://...>` Jazz sync endpoint (default `wss://sync.alkalye.com`)
+- `--timeout <ms>` reserved for future sync waits
+
+## Auth material
+
+For any docs command, provide one of:
+
+- `--session-account-id <co_...> --session-secret <sealerSecret_...>`
+- `--session-file <json-file>` containing `{ "accountID": "...", "accountSecret": "..." }`
+- passphrase flags (`--passphrase`, `--passphrase-env`, `--passphrase-file`, `--passphrase-stdin`)
 
 ## Auth commands
 
-- `auth sign-in`
-- `auth sign-out`
+- `auth sign-in` (derives session credentials from passphrase)
+- `auth create-account` (prepares deterministic account credentials from passphrase)
 - `auth status`
-- `auth create-account`
+- `auth sign-out`
 
-Passphrase sources:
-
-- `--passphrase "word1 word2 ..."`
-- `--passphrase-env ALK_PASS`
-- `--passphrase-file /secure/path/passphrase.txt`
-- `--passphrase-stdin`
-
-Examples:
+Example:
 
 ```bash
-bun run cli -- auth sign-in --passphrase-env ALK_PASS
-printf 'word1 word2 word3' | bun run cli -- auth sign-in --passphrase-stdin
-bun run cli -- auth create-account --name "Agent Writer" --passphrase-file /tmp/passphrase.txt
-```
-
-If backend create-account is unavailable, CLI returns:
-
-```json
-{"ok":false,"command":"auth.create-account","error":{"code":"not_supported","message":"Operation not supported by backend"}}
+bun run cli -- auth sign-in --passphrase-env ALK_PASS > /tmp/alk-session.json
 ```
 
 ## Docs commands
@@ -66,23 +46,4 @@ If backend create-account is unavailable, CLI returns:
 - `docs delete --doc-id <id> [--soft-delete|--hard-delete]`
 - `docs upsert --space-id <id> --title <title> --content <content>`
 
-Upsert behavior:
-
-1. list/search docs in the space by title
-2. update exact title match if found
-3. create if no exact title match exists
-
-Examples:
-
-```bash
-bun run cli -- docs create --space-id sp_123 --title "Spec" --content "v1"
-bun run cli -- docs update --doc-id doc_123 --append --content "\nnew note"
-bun run cli -- docs list --space-id sp_123 --query roadmap
-bun run cli -- docs upsert --space-id sp_123 --title "Roadmap" --content "Q2 plan"
-```
-
-## Safety notes
-
-- Prefer env/file/stdin passphrase sources over shell history.
-- `--hard-delete` requests permanent delete and may be irreversible.
-- Non-2xx HTTP responses are mapped into JSON errors with status/details when available.
+Upsert uses title matching from document heading (`# Title`).

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"dev": "astro dev",
 		"build": "astro check && astro build",
+		"cli": "bun run src/cli/main.ts",
 		"check": "bun x concurrently \"bun run check:lint\" \"bun run check:types\" \"bun run check:format\" \"bun run check:test\"",
 		"check:lint": "eslint .",
 		"check:types": "astro check",
@@ -19,7 +20,8 @@
 		"test:e2e:headed": "playwright test --headed",
 		"preview": "astro preview",
 		"format": "prettier --write .",
-		"test": "vitest"
+		"test": "vitest",
+		"test:cli": "bun vitest run src/cli"
 	},
 	"dependencies": {
 		"@base-ui/react": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
 		"preview": "astro preview",
 		"format": "prettier --write .",
 		"test": "vitest",
-		"test:cli": "bun vitest run src/cli"
+		"test:cli": "bun vitest run src/cli",
+		"test:cli:smoke": "bash scripts/cli-smoke.sh"
 	},
 	"dependencies": {
 		"@base-ui/react": "^1.1.0",
@@ -49,6 +50,8 @@
 		"astro": "^5.16.15",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
+		"cojson": "^0.20.4",
+		"cojson-transport-ws": "^0.20.4",
 		"dompurify": "^3.3.1",
 		"fast-myers-diff": "^3.2.0",
 		"idb-keyval": "^6.2.2",

--- a/scripts/cli-smoke.sh
+++ b/scripts/cli-smoke.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+CLI=(bun run "$ROOT_DIR/src/cli/main.ts")
+
+SYNC_URL="${ALK_SYNC_URL:-ws://127.0.0.1:4200}"
+SESSION_FILE="${ALK_SESSION_FILE:-$ROOT_DIR/.tmp/cli-session.json}"
+PASSPHRASE_FILE="${ALK_PASSPHRASE_FILE:-$ROOT_DIR/.tmp/cli-passphrase.txt}"
+SPACE_ID="${ALK_TEST_SPACE_ID:-}"
+SYNC_START_CMD="${ALK_SYNC_START_CMD:-}"
+
+mkdir -p "$(dirname "$SESSION_FILE")" "$(dirname "$PASSPHRASE_FILE")"
+if [[ ! -s "$PASSPHRASE_FILE" ]]; then
+  printf 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about\n' > "$PASSPHRASE_FILE"
+fi
+
+SYNC_PID=""
+cleanup() {
+  if [[ -n "${DOC_ID:-}" ]]; then
+    "${CLI[@]}" docs delete --sync-url "$SYNC_URL" --doc-id "$DOC_ID" --hard-delete --session-file "$SESSION_FILE" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$SYNC_PID" ]]; then
+    kill "$SYNC_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+if [[ -n "$SYNC_START_CMD" ]]; then
+  bash -lc "$SYNC_START_CMD" >/tmp/alk-sync.log 2>&1 &
+  SYNC_PID=$!
+  sleep 2
+fi
+
+run() {
+  local out
+  out=$("${CLI[@]}" "$@")
+  node -e 'const x=JSON.parse(process.argv[1]); if(!x.ok){console.error(JSON.stringify(x)); process.exit(1)}' "$out"
+  echo "$out"
+}
+
+run auth create-account --sync-url "$SYNC_URL" --name "CLI Smoke" --passphrase-file "$PASSPHRASE_FILE" --session-file "$SESSION_FILE" >/dev/null || true
+run auth sign-in --sync-url "$SYNC_URL" --passphrase-file "$PASSPHRASE_FILE" --session-file "$SESSION_FILE" >/dev/null
+run auth status --session-file "$SESSION_FILE" >/dev/null
+
+if [[ -z "$SPACE_ID" ]]; then
+  SPACE_ID=$(bun -e 'import { startWorker } from "jazz-tools/worker"; import { createSpace, UserAccount } from "./src/schema/index.ts"; import { readFileSync } from "node:fs"; const session = JSON.parse(readFileSync(process.argv[1], "utf8")); const syncServer = process.argv[2]; const wrk = await startWorker({syncServer, accountID: session.accountID, accountSecret: session.accountSecret, AccountSchema: UserAccount}); const me = await UserAccount.getMe().$jazz.ensureLoaded({resolve:{root:{spaces:true}}}); const space = createSpace(`cli-smoke-${Date.now()}`, me.root); await wrk.worker.$jazz.waitForAllCoValuesSync(); process.stdout.write(space.$jazz.id); await wrk.shutdownWorker();' "$SESSION_FILE" "$SYNC_URL")
+fi
+
+CREATE=$(run docs create --sync-url "$SYNC_URL" --space-id "$SPACE_ID" --title "cli-smoke-$(date +%s)" --content "hello" --session-file "$SESSION_FILE")
+DOC_ID=$(node -e 'const x=JSON.parse(process.argv[1]); process.stdout.write(x.data.docId)' "$CREATE")
+
+run docs read --sync-url "$SYNC_URL" --doc-id "$DOC_ID" --session-file "$SESSION_FILE" >/dev/null
+run docs update --sync-url "$SYNC_URL" --doc-id "$DOC_ID" --content "updated" --replace --session-file "$SESSION_FILE" >/dev/null
+run docs upsert --sync-url "$SYNC_URL" --space-id "$SPACE_ID" --title "cli-smoke-upsert" --content "upsert body" --session-file "$SESSION_FILE" >/dev/null
+run docs list --sync-url "$SYNC_URL" --space-id "$SPACE_ID" --session-file "$SESSION_FILE" >/dev/null
+run docs search --sync-url "$SYNC_URL" --space-id "$SPACE_ID" --query "cli-smoke" --session-file "$SESSION_FILE" >/dev/null
+run docs delete --sync-url "$SYNC_URL" --doc-id "$DOC_ID" --hard-delete --session-file "$SESSION_FILE" >/dev/null
+
+echo "CLI smoke passed"

--- a/skills/alkalye-playwright-crud/helpers/auth-helpers.ts
+++ b/skills/alkalye-playwright-crud/helpers/auth-helpers.ts
@@ -33,14 +33,207 @@ interface SignOutArgs {
 
 async function waitForEditorBoot(page: Page, args: WaitForEditorBootArgs = {}) {
 	let path = args.path ?? "/app"
+	let bootStart = Date.now()
 	await page.goto(path)
-	await expect
-		.poll(async () => {
-			return page.evaluate(() => {
-				return document.body.getAttribute("data-alkalye-ready")
-			})
+
+	type BootAttemptDiagnostic = {
+		attempt: number
+		timeoutMs: number
+		elapsedMs: number
+		attemptDurationMs: number
+		status: "ready" | "not-ready"
+		url: string
+		title: string
+		bodyReadyAttr: string | null
+		windowReady: boolean | null
+		windowReadyRoute: string | null
+		bodyTextSnippet: string
+		fallback?: boolean
+		signals: {
+			settingsSignIn: { present: boolean; visible: boolean }
+			settingsSignOut: { present: boolean; visible: boolean }
+			authDialog: { present: boolean; visible: boolean }
+			editorTextbox: { present: boolean; visible: boolean }
+			docControls: { present: boolean; visible: boolean }
+			settingsSectionCloud: { present: boolean; visible: boolean }
+		}
+	}
+
+	let diagnostics: BootAttemptDiagnostic[] = []
+	let ready = false
+	for (let attempt = 0; attempt < 3; attempt++) {
+		let timeout = 10_000 + attempt * 10_000
+		let attemptStart = Date.now()
+		let signal = await expect
+			.poll(
+				async () => {
+					return page.evaluate(() => {
+						let byAttr = document.body.getAttribute("data-alkalye-ready")
+						let byWindow = (window as { __alkalyeReady?: boolean }).__alkalyeReady
+						if (byAttr === "true" || byWindow === true) return "true"
+
+						let hasSettings = Boolean(document.querySelector('[data-testid="settings-section-cloud"]'))
+						let hasEditor = Boolean(document.querySelector('[data-testid="doc-editor-textarea"], [role="textbox"], textarea'))
+						return hasSettings || hasEditor ? "true" : "false"
+					})
+				},
+				{ timeout },
+			)
+			.toBe("true")
+			.then(() => true)
+			.catch(() => false)
+
+		let attemptDiagnostic = await page.evaluate((meta) => {
+			let selectInfo = (selector: string) => {
+				let el = document.querySelector(selector)
+				if (!el) return { present: false, visible: false }
+				let rect = (el as HTMLElement).getBoundingClientRect()
+				let style = window.getComputedStyle(el as Element)
+				let visible =
+					rect.width > 0 &&
+					rect.height > 0 &&
+					style.visibility !== "hidden" &&
+					style.display !== "none" &&
+					style.opacity !== "0"
+				return { present: true, visible }
+			}
+
+			let bodyTextSnippet = document.body?.innerText?.replace(/\s+/g, " ").trim().slice(0, 500) ?? ""
+			let windowObj = window as {
+				__alkalyeReady?: boolean
+				__alkalyeReadyRoute?: string
+			}
+
+			return {
+				attempt: meta.attempt,
+				timeoutMs: meta.timeout,
+				elapsedMs: Date.now() - meta.bootStart,
+				attemptDurationMs: Date.now() - meta.attemptStart,
+				status: meta.signal ? "ready" : "not-ready",
+				url: window.location.href,
+				title: document.title,
+				bodyReadyAttr: document.body?.getAttribute("data-alkalye-ready") ?? null,
+				windowReady: windowObj.__alkalyeReady ?? null,
+				windowReadyRoute: windowObj.__alkalyeReadyRoute ?? null,
+				bodyTextSnippet,
+				signals: {
+					settingsSignIn: selectInfo('[data-testid="settings-sign-in"]'),
+					settingsSignOut: selectInfo('[data-testid="settings-sign-out"]'),
+					authDialog: selectInfo('[data-testid="auth-dialog"], [role="dialog"]'),
+					editorTextbox: selectInfo('[data-testid="doc-editor-textarea"], [role="textbox"], textarea'),
+					docControls: selectInfo('[data-testid="doc-new-button"], [data-testid="doc-list"], [data-testid="doc-editor"], [data-testid="editor-toolbar"]'),
+					settingsSectionCloud: selectInfo('[data-testid="settings-section-cloud"]'),
+				},
+			}
+		}, { attempt: attempt + 1, timeout, bootStart, attemptStart, signal })
+
+		diagnostics.push(attemptDiagnostic)
+		console.log(`[ALK_BOOT_DIAG] ${JSON.stringify(attemptDiagnostic)}`)
+
+		if (signal) {
+			ready = true
+			break
+		}
+
+		// Pi + prod can take longer / stall once; force hard reload and retry.
+		await page.reload({ waitUntil: "domcontentloaded", timeout: 15_000 }).catch(() => {})
+	}
+
+	if (!ready) {
+		let shouldTrySlowFallback = diagnostics.length >= 3 && diagnostics.every((d) => {
+			return (
+				d.windowReadyRoute === "boot" &&
+				d.bodyReadyAttr === "false" &&
+				!d.signals.editorTextbox.present &&
+				!d.signals.settingsSectionCloud.present
+			)
 		})
-		.toBe("true")
+
+		if (shouldTrySlowFallback) {
+			let fallbackTimeoutMs = 45_000
+			let fallbackStart = Date.now()
+			let fallbackSignal = await expect
+				.poll(
+					async () => {
+						return page.evaluate(() => {
+							let byAttr = document.body.getAttribute("data-alkalye-ready")
+							let byWindow = (window as { __alkalyeReady?: boolean }).__alkalyeReady
+							let hasSettings = Boolean(document.querySelector('[data-testid="settings-section-cloud"]'))
+							let hasEditor = Boolean(document.querySelector('[data-testid="doc-editor-textarea"], [role="textbox"], textarea'))
+							return byAttr === "true" || byWindow === true || hasSettings || hasEditor ? "true" : "false"
+						})
+					},
+					{ timeout: fallbackTimeoutMs, intervals: [1_000] },
+				)
+				.toBe("true")
+				.then(() => true)
+				.catch(() => false)
+
+			let fallbackDiagnostic = await page.evaluate((meta) => {
+				let selectInfo = (selector: string) => {
+					let el = document.querySelector(selector)
+					if (!el) return { present: false, visible: false }
+					let rect = (el as HTMLElement).getBoundingClientRect()
+					let style = window.getComputedStyle(el as Element)
+					let visible =
+						rect.width > 0 &&
+						rect.height > 0 &&
+						style.visibility !== "hidden" &&
+						style.display !== "none" &&
+						style.opacity !== "0"
+					return { present: true, visible }
+				}
+				let bodyTextSnippet = document.body?.innerText?.replace(/\s+/g, " ").trim().slice(0, 500) ?? ""
+				let windowObj = window as {
+					__alkalyeReady?: boolean
+					__alkalyeReadyRoute?: string
+				}
+				return {
+					attempt: meta.attempt,
+					timeoutMs: meta.timeout,
+					elapsedMs: Date.now() - meta.bootStart,
+					attemptDurationMs: Date.now() - meta.attemptStart,
+					status: meta.signal ? "ready" : "not-ready",
+					url: window.location.href,
+					title: document.title,
+					bodyReadyAttr: document.body?.getAttribute("data-alkalye-ready") ?? null,
+					windowReady: windowObj.__alkalyeReady ?? null,
+					windowReadyRoute: windowObj.__alkalyeReadyRoute ?? null,
+					bodyTextSnippet,
+					fallback: true,
+					signals: {
+						settingsSignIn: selectInfo('[data-testid="settings-sign-in"]'),
+						settingsSignOut: selectInfo('[data-testid="settings-sign-out"]'),
+						authDialog: selectInfo('[data-testid="auth-dialog"], [role="dialog"]'),
+						editorTextbox: selectInfo('[data-testid="doc-editor-textarea"], [role="textbox"], textarea'),
+						docControls: selectInfo('[data-testid="doc-new-button"], [data-testid="doc-list"], [data-testid="doc-editor"], [data-testid="editor-toolbar"]'),
+						settingsSectionCloud: selectInfo('[data-testid="settings-section-cloud"]'),
+					},
+				}
+			}, {
+				attempt: diagnostics.length + 1,
+				timeout: fallbackTimeoutMs,
+				bootStart,
+				attemptStart: fallbackStart,
+				signal: fallbackSignal,
+			})
+			diagnostics.push(fallbackDiagnostic as BootAttemptDiagnostic)
+			console.log(`[ALK_BOOT_DIAG_FALLBACK] ${JSON.stringify(fallbackDiagnostic)}`)
+			ready = fallbackSignal
+		}
+	}
+
+	if (!ready) {
+		let payload = {
+			type: "EditorBootTimeout",
+			attempts: diagnostics.length,
+			totalElapsedMs: Date.now() - bootStart,
+			diagnostics,
+		}
+		let error = new Error(`Editor boot timeout diagnostics: ${JSON.stringify(payload)}`)
+		;(error as Error & { diagnostics?: typeof payload }).diagnostics = payload
+		throw error
+	}
 
 	let route = await page.evaluate(() => {
 		return (
@@ -81,7 +274,7 @@ async function createAccount(page: Page, args: CreateAccountArgs = {}) {
 
 	let dialog = page.getByTestId(testIds.auth.dialog)
 	let didClose = await expect(dialog)
-		.toBeHidden({ timeout: 5_000 })
+		.toBeHidden({ timeout: 20_000 })
 		.then(() => true)
 		.catch(() => false)
 
@@ -97,7 +290,7 @@ async function createAccount(page: Page, args: CreateAccountArgs = {}) {
 
 	await openSettings(page)
 	await expect(page.getByTestId(testIds.auth.settingsSignOut)).toBeVisible({
-		timeout: 30_000,
+		timeout: 60_000,
 	})
 
 	return {
@@ -133,7 +326,7 @@ async function signIn(page: Page, args: SignInArgs) {
 
 	let dialog = page.getByTestId(testIds.auth.dialog)
 	let didClose = await expect(dialog)
-		.toBeHidden({ timeout: 10_000 })
+		.toBeHidden({ timeout: 25_000 })
 		.then(() => true)
 		.catch(() => false)
 	if (!didClose) {
@@ -148,7 +341,7 @@ async function signIn(page: Page, args: SignInArgs) {
 
 	await openSettings(page)
 	await expect(page.getByTestId(testIds.auth.settingsSignOut)).toBeVisible({
-		timeout: 30_000,
+		timeout: 60_000,
 	})
 
 	return {

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+import { parseArgs } from "./args"
+
+describe("parseArgs", () => {
+	it("parses docs create with required options", () => {
+		let result = parseArgs([
+			"docs",
+			"create",
+			"--space-id",
+			"space-1",
+			"--title",
+			"My doc",
+			"--content",
+			"Hello",
+			"--timeout",
+			"5000",
+		])
+
+		expect(result.ok).toBe(true)
+		if (!result.ok) return
+		expect(result.value.spaceId).toBe("space-1")
+		expect(result.value.title).toBe("My doc")
+		expect(result.value.timeoutMs).toBe(5000)
+	})
+
+	it("rejects invalid timeout", () => {
+		let result = parseArgs([
+			"docs",
+			"create",
+			"--space-id",
+			"space-1",
+			"--title",
+			"My doc",
+			"--content",
+			"Hello",
+			"--timeout",
+			"0",
+		])
+
+		expect(result).toEqual({
+			ok: false,
+			code: "invalid_timeout",
+			message: "Timeout must be a positive integer (milliseconds)",
+		})
+	})
+
+	it("requires doc id for read", () => {
+		let result = parseArgs(["docs", "read"])
+		expect(result).toEqual({
+			ok: false,
+			code: "missing_required_option",
+			message: "Missing required option --doc-id",
+		})
+	})
+
+	it("supports auth sign in with stdin passphrase", () => {
+		let result = parseArgs(["auth", "sign-in", "--passphrase-stdin"])
+		expect(result.ok).toBe(true)
+		if (!result.ok) return
+		expect(result.value.passphraseStdin).toBe(true)
+	})
+
+	it("rejects unknown flag", () => {
+		let result = parseArgs(["auth", "status", "--wat"])
+		expect(result).toEqual({
+			ok: false,
+			code: "unknown_flag",
+			message: "Unknown option: --wat",
+		})
+	})
+})

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,0 +1,250 @@
+import type { ParsedArgs } from "./types"
+
+export { DEFAULT_BASE_URL, parseArgs }
+
+let DEFAULT_BASE_URL = "https://www.alkalye.com/api/agent/v1"
+
+type ParseOutcome =
+	| { ok: true; value: ParsedArgs }
+	| { ok: false; code: string; message: string }
+
+function parseArgs(argv: string[]): ParseOutcome {
+	if (argv.length < 2) {
+		return {
+			ok: false,
+			code: "invalid_arguments",
+			message: "Expected command and action",
+		}
+	}
+
+	let commandToken = argv[0]
+	let actionToken = argv[1]
+	if (commandToken !== "auth" && commandToken !== "docs") {
+		return {
+			ok: false,
+			code: "invalid_command",
+			message: `Unsupported command: ${commandToken}`,
+		}
+	}
+
+	if (commandToken === "auth") {
+		if (
+			actionToken !== "sign-in" &&
+			actionToken !== "sign-out" &&
+			actionToken !== "status" &&
+			actionToken !== "create-account"
+		) {
+			return {
+				ok: false,
+				code: "invalid_action",
+				message: `Unsupported auth action: ${actionToken}`,
+			}
+		}
+
+		let parsed: ParsedArgs = baseArgs("auth", actionToken)
+		let optionResult = parseOptions(argv, parsed)
+		if (!optionResult.ok) return optionResult
+		return validate(optionResult.value)
+	}
+
+	if (
+		actionToken !== "create" &&
+		actionToken !== "read" &&
+		actionToken !== "update" &&
+		actionToken !== "list" &&
+		actionToken !== "search" &&
+		actionToken !== "delete" &&
+		actionToken !== "upsert"
+	) {
+		return {
+			ok: false,
+			code: "invalid_action",
+			message: `Unsupported docs action: ${actionToken}`,
+		}
+	}
+
+	let parsed: ParsedArgs = baseArgs("docs", actionToken)
+	let optionResult = parseOptions(argv, parsed)
+	if (!optionResult.ok) return optionResult
+	return validate(optionResult.value)
+}
+
+function baseArgs(
+	command: "auth" | "docs",
+	action: ParsedArgs["action"],
+): ParsedArgs {
+	return {
+		command,
+		action,
+		baseUrl: DEFAULT_BASE_URL,
+		timeoutMs: 10_000,
+		headless: true,
+		append: false,
+		softDelete: true,
+		passphraseStdin: false,
+	}
+}
+
+function parseOptions(argv: string[], parsed: ParsedArgs): ParseOutcome {
+	let idx = 2
+	while (idx < argv.length) {
+		let token = argv[idx]
+		let next = argv[idx + 1]
+
+		switch (token) {
+			case "--base-url":
+				if (!next) return missingValue(token)
+				parsed.baseUrl = next
+				idx += 2
+				break
+			case "--space-id":
+				if (!next) return missingValue(token)
+				parsed.spaceId = next
+				idx += 2
+				break
+			case "--doc-id":
+				if (!next) return missingValue(token)
+				parsed.docId = next
+				idx += 2
+				break
+			case "--title":
+				if (!next) return missingValue(token)
+				parsed.title = next
+				idx += 2
+				break
+			case "--content":
+				if (!next) return missingValue(token)
+				parsed.content = next
+				idx += 2
+				break
+			case "--query":
+				if (!next) return missingValue(token)
+				parsed.query = next
+				idx += 2
+				break
+			case "--name":
+				if (!next) return missingValue(token)
+				parsed.name = next
+				idx += 2
+				break
+			case "--passphrase":
+				if (!next) return missingValue(token)
+				parsed.passphrase = next
+				idx += 2
+				break
+			case "--passphrase-env":
+				if (!next) return missingValue(token)
+				parsed.passphraseEnv = next
+				idx += 2
+				break
+			case "--passphrase-file":
+				if (!next) return missingValue(token)
+				parsed.passphraseFile = next
+				idx += 2
+				break
+			case "--passphrase-stdin":
+				parsed.passphraseStdin = true
+				idx += 1
+				break
+			case "--timeout": {
+				if (!next) return missingValue(token)
+				let parsedTimeout = Number.parseInt(next, 10)
+				if (!Number.isFinite(parsedTimeout) || parsedTimeout <= 0) {
+					return {
+						ok: false,
+						code: "invalid_timeout",
+						message: "Timeout must be a positive integer (milliseconds)",
+					}
+				}
+				parsed.timeoutMs = parsedTimeout
+				idx += 2
+				break
+			}
+			case "--headless":
+				parsed.headless = true
+				idx += 1
+				break
+			case "--no-headless":
+				parsed.headless = false
+				idx += 1
+				break
+			case "--append":
+				parsed.append = true
+				idx += 1
+				break
+			case "--replace":
+				parsed.append = false
+				idx += 1
+				break
+			case "--hard-delete":
+				parsed.softDelete = false
+				idx += 1
+				break
+			case "--soft-delete":
+				parsed.softDelete = true
+				idx += 1
+				break
+			default:
+				return {
+					ok: false,
+					code: "unknown_flag",
+					message: `Unknown option: ${token}`,
+				}
+		}
+	}
+
+	return { ok: true, value: parsed }
+}
+
+function missingValue(flag: string): ParseOutcome {
+	return {
+		ok: false,
+		code: "missing_flag_value",
+		message: `Expected value for ${flag}`,
+	}
+}
+
+function validate(parsed: ParsedArgs): ParseOutcome {
+	if (parsed.command === "docs" && parsed.action === "create") {
+		if (!parsed.spaceId) return required("space-id")
+		if (!parsed.title) return required("title")
+		if (parsed.content === undefined) return required("content")
+	}
+
+	if (parsed.command === "docs" && parsed.action === "read" && !parsed.docId) {
+		return required("doc-id")
+	}
+
+	if (parsed.command === "docs" && parsed.action === "update") {
+		if (!parsed.docId) return required("doc-id")
+		if (parsed.content === undefined) return required("content")
+	}
+
+	if (
+		parsed.command === "docs" &&
+		(parsed.action === "list" || parsed.action === "search") &&
+		!parsed.spaceId
+	) {
+		return required("space-id")
+	}
+
+	if (parsed.command === "docs" && parsed.action === "delete" && !parsed.docId) {
+		return required("doc-id")
+	}
+
+	if (parsed.command === "docs" && parsed.action === "upsert") {
+		if (!parsed.spaceId) return required("space-id")
+		if (!parsed.title) return required("title")
+		if (parsed.content === undefined) return required("content")
+	}
+
+	return { ok: true, value: parsed }
+}
+
+function required(name: string): ParseOutcome {
+	return {
+		ok: false,
+		code: "missing_required_option",
+		message: `Missing required option --${name}`,
+	}
+}

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,8 +1,8 @@
 import type { ParsedArgs } from "./types"
 
-export { DEFAULT_BASE_URL, parseArgs }
+export { DEFAULT_SYNC_URL, parseArgs }
 
-let DEFAULT_BASE_URL = "https://www.alkalye.com/api/agent/v1"
+let DEFAULT_SYNC_URL = "wss://sync.alkalye.com"
 
 type ParseOutcome =
 	| { ok: true; value: ParsedArgs }
@@ -20,47 +20,21 @@ function parseArgs(argv: string[]): ParseOutcome {
 	let commandToken = argv[0]
 	let actionToken = argv[1]
 	if (commandToken !== "auth" && commandToken !== "docs") {
-		return {
-			ok: false,
-			code: "invalid_command",
-			message: `Unsupported command: ${commandToken}`,
-		}
+		return { ok: false, code: "invalid_command", message: `Unsupported command: ${commandToken}` }
 	}
 
 	if (commandToken === "auth") {
-		if (
-			actionToken !== "sign-in" &&
-			actionToken !== "sign-out" &&
-			actionToken !== "status" &&
-			actionToken !== "create-account"
-		) {
-			return {
-				ok: false,
-				code: "invalid_action",
-				message: `Unsupported auth action: ${actionToken}`,
-			}
+		if (actionToken !== "sign-in" && actionToken !== "sign-out" && actionToken !== "status" && actionToken !== "create-account") {
+			return { ok: false, code: "invalid_action", message: `Unsupported auth action: ${actionToken}` }
 		}
-
 		let parsed: ParsedArgs = baseArgs("auth", actionToken)
 		let optionResult = parseOptions(argv, parsed)
 		if (!optionResult.ok) return optionResult
 		return validate(optionResult.value)
 	}
 
-	if (
-		actionToken !== "create" &&
-		actionToken !== "read" &&
-		actionToken !== "update" &&
-		actionToken !== "list" &&
-		actionToken !== "search" &&
-		actionToken !== "delete" &&
-		actionToken !== "upsert"
-	) {
-		return {
-			ok: false,
-			code: "invalid_action",
-			message: `Unsupported docs action: ${actionToken}`,
-		}
+	if (actionToken !== "create" && actionToken !== "read" && actionToken !== "update" && actionToken !== "list" && actionToken !== "search" && actionToken !== "delete" && actionToken !== "upsert") {
+		return { ok: false, code: "invalid_action", message: `Unsupported docs action: ${actionToken}` }
 	}
 
 	let parsed: ParsedArgs = baseArgs("docs", actionToken)
@@ -69,16 +43,12 @@ function parseArgs(argv: string[]): ParseOutcome {
 	return validate(optionResult.value)
 }
 
-function baseArgs(
-	command: "auth" | "docs",
-	action: ParsedArgs["action"],
-): ParsedArgs {
+function baseArgs(command: "auth" | "docs", action: ParsedArgs["action"]): ParsedArgs {
 	return {
 		command,
 		action,
-		baseUrl: DEFAULT_BASE_URL,
+		syncUrl: DEFAULT_SYNC_URL,
 		timeoutMs: 10_000,
-		headless: true,
 		append: false,
 		softDelete: true,
 		passphraseStdin: false,
@@ -90,118 +60,41 @@ function parseOptions(argv: string[], parsed: ParsedArgs): ParseOutcome {
 	while (idx < argv.length) {
 		let token = argv[idx]
 		let next = argv[idx + 1]
-
 		switch (token) {
-			case "--base-url":
-				if (!next) return missingValue(token)
-				parsed.baseUrl = next
-				idx += 2
-				break
-			case "--space-id":
-				if (!next) return missingValue(token)
-				parsed.spaceId = next
-				idx += 2
-				break
-			case "--doc-id":
-				if (!next) return missingValue(token)
-				parsed.docId = next
-				idx += 2
-				break
-			case "--title":
-				if (!next) return missingValue(token)
-				parsed.title = next
-				idx += 2
-				break
-			case "--content":
-				if (!next) return missingValue(token)
-				parsed.content = next
-				idx += 2
-				break
-			case "--query":
-				if (!next) return missingValue(token)
-				parsed.query = next
-				idx += 2
-				break
-			case "--name":
-				if (!next) return missingValue(token)
-				parsed.name = next
-				idx += 2
-				break
-			case "--passphrase":
-				if (!next) return missingValue(token)
-				parsed.passphrase = next
-				idx += 2
-				break
-			case "--passphrase-env":
-				if (!next) return missingValue(token)
-				parsed.passphraseEnv = next
-				idx += 2
-				break
-			case "--passphrase-file":
-				if (!next) return missingValue(token)
-				parsed.passphraseFile = next
-				idx += 2
-				break
-			case "--passphrase-stdin":
-				parsed.passphraseStdin = true
-				idx += 1
-				break
+			case "--sync-url": if (!next) return missingValue(token); parsed.syncUrl = next; idx += 2; break
+			case "--space-id": if (!next) return missingValue(token); parsed.spaceId = next; idx += 2; break
+			case "--doc-id": if (!next) return missingValue(token); parsed.docId = next; idx += 2; break
+			case "--title": if (!next) return missingValue(token); parsed.title = next; idx += 2; break
+			case "--content": if (!next) return missingValue(token); parsed.content = next; idx += 2; break
+			case "--query": if (!next) return missingValue(token); parsed.query = next; idx += 2; break
+			case "--name": if (!next) return missingValue(token); parsed.name = next; idx += 2; break
+			case "--passphrase": if (!next) return missingValue(token); parsed.passphrase = next; idx += 2; break
+			case "--passphrase-env": if (!next) return missingValue(token); parsed.passphraseEnv = next; idx += 2; break
+			case "--passphrase-file": if (!next) return missingValue(token); parsed.passphraseFile = next; idx += 2; break
+			case "--passphrase-stdin": parsed.passphraseStdin = true; idx += 1; break
+			case "--session-file": if (!next) return missingValue(token); parsed.sessionFile = next; idx += 2; break
+			case "--session-account-id": if (!next) return missingValue(token); parsed.sessionAccountId = next; idx += 2; break
+			case "--session-secret": if (!next) return missingValue(token); parsed.sessionSecret = next; idx += 2; break
 			case "--timeout": {
 				if (!next) return missingValue(token)
 				let parsedTimeout = Number.parseInt(next, 10)
-				if (!Number.isFinite(parsedTimeout) || parsedTimeout <= 0) {
-					return {
-						ok: false,
-						code: "invalid_timeout",
-						message: "Timeout must be a positive integer (milliseconds)",
-					}
-				}
+				if (!Number.isFinite(parsedTimeout) || parsedTimeout <= 0) return { ok: false, code: "invalid_timeout", message: "Timeout must be a positive integer (milliseconds)" }
 				parsed.timeoutMs = parsedTimeout
 				idx += 2
 				break
 			}
-			case "--headless":
-				parsed.headless = true
-				idx += 1
-				break
-			case "--no-headless":
-				parsed.headless = false
-				idx += 1
-				break
-			case "--append":
-				parsed.append = true
-				idx += 1
-				break
-			case "--replace":
-				parsed.append = false
-				idx += 1
-				break
-			case "--hard-delete":
-				parsed.softDelete = false
-				idx += 1
-				break
-			case "--soft-delete":
-				parsed.softDelete = true
-				idx += 1
-				break
-			default:
-				return {
-					ok: false,
-					code: "unknown_flag",
-					message: `Unknown option: ${token}`,
-				}
+			case "--append": parsed.append = true; idx += 1; break
+			case "--replace": parsed.append = false; idx += 1; break
+			case "--hard-delete": parsed.softDelete = false; idx += 1; break
+			case "--soft-delete": parsed.softDelete = true; idx += 1; break
+			default: return { ok: false, code: "unknown_flag", message: `Unknown option: ${token}` }
 		}
 	}
-
 	return { ok: true, value: parsed }
 }
 
 function missingValue(flag: string): ParseOutcome {
-	return {
-		ok: false,
-		code: "missing_flag_value",
-		message: `Expected value for ${flag}`,
-	}
+	return { ok: false, code: "missing_flag_value", message: `Expected value for ${flag}` }
 }
 
 function validate(parsed: ParsedArgs): ParseOutcome {
@@ -210,41 +103,21 @@ function validate(parsed: ParsedArgs): ParseOutcome {
 		if (!parsed.title) return required("title")
 		if (parsed.content === undefined) return required("content")
 	}
-
-	if (parsed.command === "docs" && parsed.action === "read" && !parsed.docId) {
-		return required("doc-id")
-	}
-
+	if (parsed.command === "docs" && parsed.action === "read" && !parsed.docId) return required("doc-id")
 	if (parsed.command === "docs" && parsed.action === "update") {
 		if (!parsed.docId) return required("doc-id")
 		if (parsed.content === undefined) return required("content")
 	}
-
-	if (
-		parsed.command === "docs" &&
-		(parsed.action === "list" || parsed.action === "search") &&
-		!parsed.spaceId
-	) {
-		return required("space-id")
-	}
-
-	if (parsed.command === "docs" && parsed.action === "delete" && !parsed.docId) {
-		return required("doc-id")
-	}
-
+	if (parsed.command === "docs" && (parsed.action === "list" || parsed.action === "search") && !parsed.spaceId) return required("space-id")
+	if (parsed.command === "docs" && parsed.action === "delete" && !parsed.docId) return required("doc-id")
 	if (parsed.command === "docs" && parsed.action === "upsert") {
 		if (!parsed.spaceId) return required("space-id")
 		if (!parsed.title) return required("title")
 		if (parsed.content === undefined) return required("content")
 	}
-
 	return { ok: true, value: parsed }
 }
 
 function required(name: string): ParseOutcome {
-	return {
-		ok: false,
-		code: "missing_required_option",
-		message: `Missing required option --${name}`,
-	}
+	return { ok: false, code: "missing_required_option", message: `Missing required option --${name}` }
 }

--- a/src/cli/cli.integration.test.ts
+++ b/src/cli/cli.integration.test.ts
@@ -1,107 +1,35 @@
 import { describe, expect, it } from "vitest"
 import { runCli } from "./commands"
-import type { JsonValue, RuntimeDeps } from "./types"
+import type { RuntimeDeps } from "./types"
 
 describe("cli integration smoke", () => {
-	it("runs auth sign-in and docs upsert flow", async () => {
-		let calls: Array<{ url: string; method: string; body?: JsonValue }> = []
-
-		let deps = createDeps(async (url, init) => {
-			let method = init?.method ?? "GET"
-			let body = parseBody(typeof init?.body === "string" ? init.body : undefined)
-			calls.push({ url, method, body })
-
-			if (url.endsWith("/auth/sign-in") && method === "POST") {
-				return new Response(JSON.stringify({ session: "ok" }), { status: 200 })
-			}
-
-			if (url.includes("/docs?") && method === "GET") {
-				return new Response(JSON.stringify([]), { status: 200 })
-			}
-
-			if (url.endsWith("/docs") && method === "POST") {
-				return new Response(JSON.stringify({ docId: "doc-1" }), { status: 201 })
-			}
-
-			return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 })
-		})
-
-		let authResult = await runCli(
-			["auth", "sign-in", "--passphrase", "word1 word2"],
-			deps,
-		)
-		expect(authResult).toEqual({
-			ok: true,
+	it("reports invalid passphrase", async () => {
+		let result = await runCli(["auth", "sign-in", "--passphrase", "word1 word2"], createDeps())
+		expect(result).toEqual({
+			ok: false,
 			command: "auth.sign-in",
-			data: { session: "ok" },
+			error: { code: "invalid_passphrase", message: "Invalid passphrase" },
 		})
+	})
 
-		let upsertResult = await runCli(
-			[
-				"docs",
-				"upsert",
-				"--space-id",
-				"space-1",
-				"--title",
-				"Roadmap",
-				"--content",
-				"Q2",
-			],
-			deps,
-		)
-		expect(upsertResult.ok).toBe(true)
-		if (!upsertResult.ok) return
-		expect(upsertResult.command).toBe("docs.upsert")
-		expect(calls.map(c => `${c.method} ${stripHost(c.url)}`)).toEqual([
-			"POST /api/agent/v1/auth/sign-in",
-			"GET /api/agent/v1/docs?spaceId=space-1&q=Roadmap",
-			"POST /api/agent/v1/docs",
-		])
+	it("fails docs list without auth material", async () => {
+		let result = await runCli(["docs", "list", "--space-id", "space-1"], createDeps())
+		expect(result).toEqual({
+			ok: false,
+			command: "docs.list",
+			error: {
+				code: "missing_session",
+				message: "Missing auth material. Provide --session-account-id/--session-secret, --session-file, or passphrase flags.",
+			},
+		})
 	})
 })
 
-function createDeps(fetchImpl: RuntimeDeps["fetch"]): RuntimeDeps {
+function createDeps(): RuntimeDeps {
 	return {
-		fetch: fetchImpl,
 		env: {},
 		readFile: async () => "",
 		readStdin: async () => "",
 		now: () => "2026-03-09T00:00:00.000Z",
 	}
-}
-
-function parseBody(body: string | undefined): JsonValue | undefined {
-	if (typeof body !== "string") return undefined
-	try {
-		let parsed: unknown = JSON.parse(body)
-		if (!isJsonValue(parsed)) return undefined
-		return parsed
-	} catch {
-		return undefined
-	}
-}
-
-function stripHost(url: string): string {
-	let parsed = new URL(url)
-	return `${parsed.pathname}${parsed.search}`
-}
-
-function isJsonValue(value: unknown): value is JsonValue {
-	if (value === null) return true
-	if (typeof value === "string") return true
-	if (typeof value === "number") return true
-	if (typeof value === "boolean") return true
-	if (Array.isArray(value)) {
-		for (let entry of value) {
-			if (!isJsonValue(entry)) return false
-		}
-		return true
-	}
-	if (typeof value === "object") {
-		for (let entry of Object.values(value)) {
-			if (!isJsonValue(entry)) return false
-		}
-		return true
-	}
-	return false
 }

--- a/src/cli/cli.integration.test.ts
+++ b/src/cli/cli.integration.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest"
+import { runCli } from "./commands"
+import type { JsonValue, RuntimeDeps } from "./types"
+
+describe("cli integration smoke", () => {
+	it("runs auth sign-in and docs upsert flow", async () => {
+		let calls: Array<{ url: string; method: string; body?: JsonValue }> = []
+
+		let deps = createDeps(async (url, init) => {
+			let method = init?.method ?? "GET"
+			let body = parseBody(typeof init?.body === "string" ? init.body : undefined)
+			calls.push({ url, method, body })
+
+			if (url.endsWith("/auth/sign-in") && method === "POST") {
+				return new Response(JSON.stringify({ session: "ok" }), { status: 200 })
+			}
+
+			if (url.includes("/docs?") && method === "GET") {
+				return new Response(JSON.stringify([]), { status: 200 })
+			}
+
+			if (url.endsWith("/docs") && method === "POST") {
+				return new Response(JSON.stringify({ docId: "doc-1" }), { status: 201 })
+			}
+
+			return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 })
+		})
+
+		let authResult = await runCli(
+			["auth", "sign-in", "--passphrase", "word1 word2"],
+			deps,
+		)
+		expect(authResult).toEqual({
+			ok: true,
+			command: "auth.sign-in",
+			data: { session: "ok" },
+		})
+
+		let upsertResult = await runCli(
+			[
+				"docs",
+				"upsert",
+				"--space-id",
+				"space-1",
+				"--title",
+				"Roadmap",
+				"--content",
+				"Q2",
+			],
+			deps,
+		)
+		expect(upsertResult.ok).toBe(true)
+		if (!upsertResult.ok) return
+		expect(upsertResult.command).toBe("docs.upsert")
+		expect(calls.map(c => `${c.method} ${stripHost(c.url)}`)).toEqual([
+			"POST /api/agent/v1/auth/sign-in",
+			"GET /api/agent/v1/docs?spaceId=space-1&q=Roadmap",
+			"POST /api/agent/v1/docs",
+		])
+	})
+})
+
+function createDeps(fetchImpl: RuntimeDeps["fetch"]): RuntimeDeps {
+	return {
+		fetch: fetchImpl,
+		env: {},
+		readFile: async () => "",
+		readStdin: async () => "",
+		now: () => "2026-03-09T00:00:00.000Z",
+	}
+}
+
+function parseBody(body: string | undefined): JsonValue | undefined {
+	if (typeof body !== "string") return undefined
+	try {
+		let parsed: unknown = JSON.parse(body)
+		if (!isJsonValue(parsed)) return undefined
+		return parsed
+	} catch {
+		return undefined
+	}
+}
+
+function stripHost(url: string): string {
+	let parsed = new URL(url)
+	return `${parsed.pathname}${parsed.search}`
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+	if (value === null) return true
+	if (typeof value === "string") return true
+	if (typeof value === "number") return true
+	if (typeof value === "boolean") return true
+	if (Array.isArray(value)) {
+		for (let entry of value) {
+			if (!isJsonValue(entry)) return false
+		}
+		return true
+	}
+	if (typeof value === "object") {
+		for (let entry of Object.values(value)) {
+			if (!isJsonValue(entry)) return false
+		}
+		return true
+	}
+	return false
+}

--- a/src/cli/cli.integration.test.ts
+++ b/src/cli/cli.integration.test.ts
@@ -29,6 +29,8 @@ function createDeps(): RuntimeDeps {
 	return {
 		env: {},
 		readFile: async () => "",
+		writeFile: async () => {},
+		mkdir: async () => {},
 		readStdin: async () => "",
 		now: () => "2026-03-09T00:00:00.000Z",
 	}

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,294 +1,234 @@
+import { Buffer } from "node:buffer"
+import * as bip39 from "@scure/bip39"
+import { cojsonInternals } from "cojson"
+import { WasmCrypto } from "cojson/crypto/WasmCrypto"
+import { createJazzContextForNewAccount, MockSessionProvider } from "jazz-tools"
+import { startWorker } from "jazz-tools/worker"
+import { WebSocketPeerWithReconnection } from "cojson-transport-ws"
 import { parseArgs } from "./args"
-import { requestJson } from "./http"
 import { resolvePassphrase } from "./passphrase"
+import { Document, Space, UserAccount, createSpaceDocument } from "../schema"
+import { wordlist } from "../lib/wordlist"
+import { permanentlyDeleteDocument } from "../lib/delete-covalue"
 import type { CliResult, JsonValue, ParsedArgs, RuntimeDeps } from "./types"
 
 export { runCli }
 
 async function runCli(argv: string[], deps: RuntimeDeps): Promise<CliResult> {
 	let parsed = parseArgs(argv)
-	if (!parsed.ok) {
-		return failure("cli", parsed.code, parsed.message)
-	}
-
-	if (parsed.value.command === "auth") {
-		return runAuth(parsed.value, deps)
-	}
-
-	if (parsed.value.command === "docs") {
-		return runDocs(parsed.value, deps)
-	}
-
+	if (!parsed.ok) return failure("cli", parsed.code, parsed.message)
+	if (parsed.value.command === "auth") return runAuth(parsed.value, deps)
+	if (parsed.value.command === "docs") return runDocs(parsed.value, deps)
 	return failure("cli", "invalid_command", "Unsupported command")
 }
 
 async function runAuth(args: ParsedArgs, deps: RuntimeDeps): Promise<CliResult> {
 	let command = `auth.${args.action}`
-
 	if (args.action === "status") {
-		return executeHttp(command, deps, {
-			baseUrl: args.baseUrl,
-			path: "/auth/status",
-			method: "GET",
-			headless: args.headless,
-			timeoutMs: args.timeoutMs,
-		})
+		let session = await resolveSession(args, deps, false)
+		return success(command, { authenticated: session.ok })
 	}
-
-	if (args.action === "sign-out") {
-		return executeHttp(command, deps, {
-			baseUrl: args.baseUrl,
-			path: "/auth/sign-out",
-			method: "POST",
-			headless: args.headless,
-			timeoutMs: args.timeoutMs,
-		})
-	}
-
+	if (args.action === "sign-out") return success(command, { signedOut: true })
 	if (args.action === "sign-in") {
 		let passphrase = await resolvePassphrase(args, deps, true)
-		if (!passphrase.ok) {
-			return failure(command, passphrase.code, passphrase.message)
+		if (!passphrase.ok || !passphrase.value) return failure(command, passphrase.code, passphrase.message)
+		try {
+			let creds = await credentialsFromPassphrase(passphrase.value)
+			return success(command, { session: creds })
+		} catch {
+			return failure(command, "invalid_passphrase", "Invalid passphrase")
 		}
-
-		return executeHttp(command, deps, {
-			baseUrl: args.baseUrl,
-			path: "/auth/sign-in",
-			method: "POST",
-			headless: args.headless,
-			timeoutMs: args.timeoutMs,
-			body: {
-				passphrase: passphrase.value ?? "",
-			},
-		})
 	}
-
 	if (args.action === "create-account") {
-		let passphrase = await resolvePassphrase(args, deps, false)
-		let body: Record<string, JsonValue> = {}
-		if (!passphrase.ok) {
-			return failure(command, passphrase.code, passphrase.message)
+		let passphrase = await resolvePassphrase(args, deps, true)
+		if (!passphrase.ok || !passphrase.value) return failure(command, passphrase.code, passphrase.message)
+		try {
+			let creds = await credentialsFromPassphrase(passphrase.value)
+			let crypto = await WasmCrypto.create()
+			let peerConn = await connectPeer(args.syncUrl)
+			let context = await createJazzContextForNewAccount({
+				creationProps: { name: args.name ?? "CLI User" },
+				initialAgentSecret: creds.accountSecret,
+				peers: [peerConn.peer],
+				crypto,
+				sessionProvider: new MockSessionProvider(),
+				AccountSchema: UserAccount,
+			})
+			await context.account.$jazz.waitForAllCoValuesSync()
+			peerConn.stop()
+			context.done()
+			return success(command, { created: true, session: creds })
+		} catch {
+			return failure(command, "invalid_passphrase", "Invalid passphrase")
 		}
-		if (passphrase.value) {
-			body.passphrase = passphrase.value
-		}
-		if (args.name) {
-			body.name = args.name
-		}
-
-		return executeHttp(command, deps, {
-			baseUrl: args.baseUrl,
-			path: "/auth/create-account",
-			method: "POST",
-			headless: args.headless,
-			timeoutMs: args.timeoutMs,
-			body,
-		})
 	}
-
 	return failure(command, "invalid_action", "Unsupported auth action")
 }
 
 async function runDocs(args: ParsedArgs, deps: RuntimeDeps): Promise<CliResult> {
 	let command = `docs.${args.action}`
-
-	if (args.action === "create") {
-		return executeHttp(command, deps, {
-			baseUrl: args.baseUrl,
-			path: "/docs",
-			method: "POST",
-			headless: args.headless,
-			timeoutMs: args.timeoutMs,
-			body: {
-				spaceId: args.spaceId ?? "",
-				title: args.title ?? "",
-				content: args.content ?? "",
-			},
-		})
-	}
-
-	if (args.action === "read") {
-		return executeHttp(command, deps, {
-			baseUrl: args.baseUrl,
-			path: `/docs/${args.docId ?? ""}`,
-			method: "GET",
-			headless: args.headless,
-			timeoutMs: args.timeoutMs,
-		})
-	}
-
-	if (args.action === "update") {
-		return executeHttp(command, deps, {
-			baseUrl: args.baseUrl,
-			path: `/docs/${args.docId ?? ""}`,
-			method: "PATCH",
-			headless: args.headless,
-			timeoutMs: args.timeoutMs,
-			body: {
-				content: args.content ?? "",
-				mode: args.append ? "append" : "replace",
-			},
-		})
-	}
-
-	if (args.action === "list" || args.action === "search") {
-		let queryString = new URLSearchParams()
-		queryString.set("spaceId", args.spaceId ?? "")
-		if (args.query) queryString.set("q", args.query)
-
-		return executeHttp(command, deps, {
-			baseUrl: args.baseUrl,
-			path: `/docs?${queryString.toString()}`,
-			method: "GET",
-			headless: args.headless,
-			timeoutMs: args.timeoutMs,
-		})
-	}
-
-	if (args.action === "delete") {
-		let queryString = new URLSearchParams()
-		queryString.set("soft", args.softDelete ? "1" : "0")
-		return executeHttp(command, deps, {
-			baseUrl: args.baseUrl,
-			path: `/docs/${args.docId ?? ""}?${queryString.toString()}`,
-			method: "DELETE",
-			headless: args.headless,
-			timeoutMs: args.timeoutMs,
-		})
-	}
-
-	if (args.action === "upsert") {
-		let listed = await requestJson(deps, {
-			baseUrl: args.baseUrl,
-			path: `/docs?${new URLSearchParams({ spaceId: args.spaceId ?? "", q: args.title ?? "" }).toString()}`,
-			method: "GET",
-			headless: args.headless,
-			timeoutMs: args.timeoutMs,
-		})
-		if (!listed.ok) {
-			return failure(command, listed.code, listed.message, {
-				status: listed.status ?? null,
-				details: listed.details ?? null,
-			})
+	let session = await resolveSession(args, deps, true)
+	if (!session.ok) return failure(command, session.code, session.message)
+	let workerResult = await startWorker({
+		syncServer: args.syncUrl,
+		accountID: session.accountID,
+		accountSecret: session.secret,
+		AccountSchema: UserAccount,
+	})
+	let worker = workerResult.worker
+	try {
+		if (args.action === "create") {
+			let space = await loadSpace(args.spaceId ?? "")
+			if (!space.$isLoaded) return failure(command, "space_not_found", "Space not found")
+			let doc = createSpaceDocument(space.$jazz.owner, composeContent(args.title ?? "", args.content ?? ""))
+			doc.$jazz.set("spaceId", space.$jazz.id)
+			space.documents.$jazz.push(doc)
+			await worker.$jazz.waitForAllCoValuesSync()
+			return success(command, serializeDoc(doc))
 		}
-
-		let foundDocId = findDocIdByTitle(listed.data, args.title ?? "")
-		if (foundDocId) {
-			let updateResult = await requestJson(deps, {
-				baseUrl: args.baseUrl,
-				path: `/docs/${foundDocId}`,
-				method: "PATCH",
-				headless: args.headless,
-				timeoutMs: args.timeoutMs,
-				body: {
-					content: args.content ?? "",
-					mode: "replace",
-				},
-			})
-			if (!updateResult.ok) {
-				return failure(command, updateResult.code, updateResult.message, {
-					status: updateResult.status ?? null,
-					details: updateResult.details ?? null,
-				})
+		if (args.action === "read") {
+			let doc = await Document.load(args.docId ?? "", { resolve: { content: true } })
+			if (!doc.$isLoaded) return failure(command, "doc_not_found", "Document not found")
+			return success(command, serializeDoc(doc))
+		}
+		if (args.action === "update") {
+			let doc = await Document.load(args.docId ?? "", { resolve: { content: true } })
+			if (!doc.$isLoaded) return failure(command, "doc_not_found", "Document not found")
+			let next = args.append ? `${doc.content.toString()}${args.content ?? ""}` : (args.content ?? "")
+			doc.$jazz.set("content", co.plainText().create(next, doc.$jazz.owner))
+			doc.$jazz.set("updatedAt", new Date())
+			await worker.$jazz.waitForAllCoValuesSync()
+			return success(command, serializeDoc(doc))
+		}
+		if (args.action === "list" || args.action === "search") {
+			let docs = await listSpaceDocs(args.spaceId ?? "")
+			let filtered = args.query ? docs.filter(d => matchesQuery(d, args.query ?? "")) : docs
+			return success(command, filtered.map(serializeDoc))
+		}
+		if (args.action === "delete") {
+			let doc = await Document.load(args.docId ?? "", { resolve: { content: true } })
+			if (!doc.$isLoaded) return failure(command, "doc_not_found", "Document not found")
+			if (args.softDelete) {
+				doc.$jazz.set("deletedAt", new Date())
+				doc.$jazz.set("updatedAt", new Date())
+			} else {
+				await permanentlyDeleteDocument(doc)
 			}
-
-			return success(command, {
-				operation: "updated",
-				docId: foundDocId,
-				result: updateResult.data,
-			})
+			await worker.$jazz.waitForAllCoValuesSync()
+			return success(command, { deleted: true, soft: args.softDelete })
 		}
+		if (args.action === "upsert") {
+			let docs = await listSpaceDocs(args.spaceId ?? "")
+			let existing = docs.find(d => extractTitle(d.content?.toString() ?? "") === (args.title ?? ""))
+			if (existing?.$isLoaded) {
+				existing.$jazz.set("content", co.plainText().create(composeContent(args.title ?? "", args.content ?? ""), existing.$jazz.owner))
+				existing.$jazz.set("updatedAt", new Date())
+				await worker.$jazz.waitForAllCoValuesSync()
+				return success(command, { operation: "updated", result: serializeDoc(existing) })
+			}
+			let space = await loadSpace(args.spaceId ?? "")
+			if (!space.$isLoaded) return failure(command, "space_not_found", "Space not found")
+			let doc = createSpaceDocument(space.$jazz.owner, composeContent(args.title ?? "", args.content ?? ""))
+			doc.$jazz.set("spaceId", space.$jazz.id)
+			space.documents.$jazz.push(doc)
+			await worker.$jazz.waitForAllCoValuesSync()
+			return success(command, { operation: "created", result: serializeDoc(doc) })
+		}
+		return failure(command, "invalid_action", "Unsupported docs action")
+	} finally {
+		await workerResult.shutdownWorker()
+	}
+}
 
-		let createResult = await requestJson(deps, {
-			baseUrl: args.baseUrl,
-			path: "/docs",
-			method: "POST",
-			headless: args.headless,
-			timeoutMs: args.timeoutMs,
-			body: {
-				spaceId: args.spaceId ?? "",
-				title: args.title ?? "",
-				content: args.content ?? "",
+async function loadSpace(spaceId: string) {
+	return Space.load(spaceId, { resolve: { documents: { $each: { content: true } } } })
+}
+
+async function listSpaceDocs(spaceId: string) {
+	let space = await loadSpace(spaceId)
+	if (!space.$isLoaded) return []
+	return space.documents.filter(doc => doc?.$isLoaded && !doc.deletedAt)
+}
+
+function matchesQuery(doc: (typeof Document)["Shape"] extends never ? never : any, query: string): boolean {
+	let text = doc.content?.toString() ?? ""
+	let title = extractTitle(text)
+	let q = query.toLowerCase()
+	return text.toLowerCase().includes(q) || title.toLowerCase().includes(q)
+}
+
+function composeContent(title: string, content: string): string {
+	if (content.trim().startsWith("#")) return content
+	return `# ${title}\n\n${content}`
+}
+
+function extractTitle(content: string): string {
+	let first = content.split("\n").find(line => line.trim().length > 0) ?? ""
+	if (first.startsWith("#")) return first.replace(/^#+\s*/, "").trim()
+	return first.slice(0, 80)
+}
+
+function serializeDoc(doc: any): JsonValue {
+	let text = doc.content?.toString() ?? ""
+	return {
+		docId: doc.$jazz.id,
+		title: extractTitle(text),
+		content: text,
+		spaceId: doc.spaceId ?? null,
+		deletedAt: doc.deletedAt ? doc.deletedAt.toISOString() : null,
+		updatedAt: doc.updatedAt?.toISOString?.() ?? null,
+	}
+}
+
+async function credentialsFromPassphrase(passphrase: string): Promise<{ accountID: string; accountSecret: string }> {
+	let crypto = await WasmCrypto.create()
+	let entropyHex = bip39.mnemonicToEntropy(passphrase, wordlist)
+	let secretSeed = Uint8Array.from(Buffer.from(entropyHex, "hex"))
+	let accountSecret = crypto.agentSecretFromSecretSeed(secretSeed)
+	let accountID = cojsonInternals.idforHeader(cojsonInternals.accountHeaderForInitialAgentSecret(accountSecret, crypto), crypto)
+	return { accountID, accountSecret }
+}
+
+async function connectPeer(syncUrl: string): Promise<{ peer: any; stop: () => void }> {
+	return await new Promise((resolve, reject) => {
+		let done = false
+		let wsPeer = new WebSocketPeerWithReconnection({
+			peer: syncUrl,
+			reconnectionTimeout: 100,
+			addPeer: peer => {
+				if (done) return
+				done = true
+				resolve({ peer, stop: () => wsPeer.disable() })
 			},
+			removePeer: () => {},
 		})
-		if (!createResult.ok) {
-			return failure(command, createResult.code, createResult.message, {
-				status: createResult.status ?? null,
-				details: createResult.details ?? null,
-			})
-		}
+		wsPeer.enable()
+		setTimeout(() => {
+			if (done) return
+			done = true
+			wsPeer.disable()
+			reject(new Error("sync_connect_timeout"))
+		}, 5_000)
+	})
+}
 
-		return success(command, {
-			operation: "created",
-			result: createResult.data,
-		})
+async function resolveSession(args: ParsedArgs, deps: RuntimeDeps, required: boolean): Promise<{ ok: true; accountID: string; secret: string } | { ok: false; code: string; message: string }> {
+	if (args.sessionAccountId && args.sessionSecret) return { ok: true, accountID: args.sessionAccountId, secret: args.sessionSecret }
+	if (args.sessionFile) {
+		try {
+			let raw = await deps.readFile(args.sessionFile)
+			let parsed = JSON.parse(raw) as { accountID?: string; accountSecret?: string }
+			if (parsed.accountID && parsed.accountSecret) return { ok: true, accountID: parsed.accountID, secret: parsed.accountSecret }
+		} catch {}
 	}
-
-	return failure(command, "invalid_action", "Unsupported docs action")
-}
-
-async function executeHttp(
-	command: string,
-	deps: RuntimeDeps,
-	options: Parameters<typeof requestJson>[1],
-): Promise<CliResult> {
-	let result = await requestJson(deps, options)
-	if (!result.ok) {
-		return failure(command, result.code, result.message, {
-			status: result.status ?? null,
-			details: result.details ?? null,
-		})
+	let passphrase = await resolvePassphrase(args, deps, false)
+	if (passphrase.ok && passphrase.value) {
+		let creds = await credentialsFromPassphrase(passphrase.value)
+		return { ok: true, accountID: creds.accountID, secret: creds.accountSecret }
 	}
-	return success(command, result.data)
+	if (required) return { ok: false, code: "missing_session", message: "Missing auth material. Provide --session-account-id/--session-secret, --session-file, or passphrase flags." }
+	return { ok: false, code: "missing_session", message: "No active session" }
 }
 
-function findDocIdByTitle(data: JsonValue, title: string): string | undefined {
-	if (!Array.isArray(data)) return undefined
-	for (let item of data) {
-		if (!isObject(item)) continue
-		let itemTitle = item.title
-		let itemDocId = getString(item, "docId") ?? getString(item, "id")
-		if (itemTitle === title && typeof itemDocId === "string" && itemDocId) {
-			return itemDocId
-		}
-	}
-	return undefined
-}
-
-function isObject(value: JsonValue): value is { [key: string]: JsonValue } {
-	return typeof value === "object" && value !== null && !Array.isArray(value)
-}
-
-function getString(
-	value: { [key: string]: JsonValue },
-	key: string,
-): string | undefined {
-	let raw = value[key]
-	if (typeof raw !== "string") return undefined
-	return raw
-}
-
-function success(command: string, data: JsonValue): CliResult {
-	return {
-		ok: true,
-		command,
-		data,
-	}
-}
-
-function failure(
-	command: string,
-	code: string,
-	message: string,
-	details?: JsonValue,
-): CliResult {
-	return {
-		ok: false,
-		command,
-		error: {
-			code,
-			message,
-			details,
-		},
-	}
-}
+function success(command: string, data: JsonValue): CliResult { return { ok: true, command, data } }
+function failure(command: string, code: string, message: string, details?: JsonValue): CliResult { return { ok: false, command, error: { code, message, details } } }

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,0 +1,294 @@
+import { parseArgs } from "./args"
+import { requestJson } from "./http"
+import { resolvePassphrase } from "./passphrase"
+import type { CliResult, JsonValue, ParsedArgs, RuntimeDeps } from "./types"
+
+export { runCli }
+
+async function runCli(argv: string[], deps: RuntimeDeps): Promise<CliResult> {
+	let parsed = parseArgs(argv)
+	if (!parsed.ok) {
+		return failure("cli", parsed.code, parsed.message)
+	}
+
+	if (parsed.value.command === "auth") {
+		return runAuth(parsed.value, deps)
+	}
+
+	if (parsed.value.command === "docs") {
+		return runDocs(parsed.value, deps)
+	}
+
+	return failure("cli", "invalid_command", "Unsupported command")
+}
+
+async function runAuth(args: ParsedArgs, deps: RuntimeDeps): Promise<CliResult> {
+	let command = `auth.${args.action}`
+
+	if (args.action === "status") {
+		return executeHttp(command, deps, {
+			baseUrl: args.baseUrl,
+			path: "/auth/status",
+			method: "GET",
+			headless: args.headless,
+			timeoutMs: args.timeoutMs,
+		})
+	}
+
+	if (args.action === "sign-out") {
+		return executeHttp(command, deps, {
+			baseUrl: args.baseUrl,
+			path: "/auth/sign-out",
+			method: "POST",
+			headless: args.headless,
+			timeoutMs: args.timeoutMs,
+		})
+	}
+
+	if (args.action === "sign-in") {
+		let passphrase = await resolvePassphrase(args, deps, true)
+		if (!passphrase.ok) {
+			return failure(command, passphrase.code, passphrase.message)
+		}
+
+		return executeHttp(command, deps, {
+			baseUrl: args.baseUrl,
+			path: "/auth/sign-in",
+			method: "POST",
+			headless: args.headless,
+			timeoutMs: args.timeoutMs,
+			body: {
+				passphrase: passphrase.value ?? "",
+			},
+		})
+	}
+
+	if (args.action === "create-account") {
+		let passphrase = await resolvePassphrase(args, deps, false)
+		let body: Record<string, JsonValue> = {}
+		if (!passphrase.ok) {
+			return failure(command, passphrase.code, passphrase.message)
+		}
+		if (passphrase.value) {
+			body.passphrase = passphrase.value
+		}
+		if (args.name) {
+			body.name = args.name
+		}
+
+		return executeHttp(command, deps, {
+			baseUrl: args.baseUrl,
+			path: "/auth/create-account",
+			method: "POST",
+			headless: args.headless,
+			timeoutMs: args.timeoutMs,
+			body,
+		})
+	}
+
+	return failure(command, "invalid_action", "Unsupported auth action")
+}
+
+async function runDocs(args: ParsedArgs, deps: RuntimeDeps): Promise<CliResult> {
+	let command = `docs.${args.action}`
+
+	if (args.action === "create") {
+		return executeHttp(command, deps, {
+			baseUrl: args.baseUrl,
+			path: "/docs",
+			method: "POST",
+			headless: args.headless,
+			timeoutMs: args.timeoutMs,
+			body: {
+				spaceId: args.spaceId ?? "",
+				title: args.title ?? "",
+				content: args.content ?? "",
+			},
+		})
+	}
+
+	if (args.action === "read") {
+		return executeHttp(command, deps, {
+			baseUrl: args.baseUrl,
+			path: `/docs/${args.docId ?? ""}`,
+			method: "GET",
+			headless: args.headless,
+			timeoutMs: args.timeoutMs,
+		})
+	}
+
+	if (args.action === "update") {
+		return executeHttp(command, deps, {
+			baseUrl: args.baseUrl,
+			path: `/docs/${args.docId ?? ""}`,
+			method: "PATCH",
+			headless: args.headless,
+			timeoutMs: args.timeoutMs,
+			body: {
+				content: args.content ?? "",
+				mode: args.append ? "append" : "replace",
+			},
+		})
+	}
+
+	if (args.action === "list" || args.action === "search") {
+		let queryString = new URLSearchParams()
+		queryString.set("spaceId", args.spaceId ?? "")
+		if (args.query) queryString.set("q", args.query)
+
+		return executeHttp(command, deps, {
+			baseUrl: args.baseUrl,
+			path: `/docs?${queryString.toString()}`,
+			method: "GET",
+			headless: args.headless,
+			timeoutMs: args.timeoutMs,
+		})
+	}
+
+	if (args.action === "delete") {
+		let queryString = new URLSearchParams()
+		queryString.set("soft", args.softDelete ? "1" : "0")
+		return executeHttp(command, deps, {
+			baseUrl: args.baseUrl,
+			path: `/docs/${args.docId ?? ""}?${queryString.toString()}`,
+			method: "DELETE",
+			headless: args.headless,
+			timeoutMs: args.timeoutMs,
+		})
+	}
+
+	if (args.action === "upsert") {
+		let listed = await requestJson(deps, {
+			baseUrl: args.baseUrl,
+			path: `/docs?${new URLSearchParams({ spaceId: args.spaceId ?? "", q: args.title ?? "" }).toString()}`,
+			method: "GET",
+			headless: args.headless,
+			timeoutMs: args.timeoutMs,
+		})
+		if (!listed.ok) {
+			return failure(command, listed.code, listed.message, {
+				status: listed.status ?? null,
+				details: listed.details ?? null,
+			})
+		}
+
+		let foundDocId = findDocIdByTitle(listed.data, args.title ?? "")
+		if (foundDocId) {
+			let updateResult = await requestJson(deps, {
+				baseUrl: args.baseUrl,
+				path: `/docs/${foundDocId}`,
+				method: "PATCH",
+				headless: args.headless,
+				timeoutMs: args.timeoutMs,
+				body: {
+					content: args.content ?? "",
+					mode: "replace",
+				},
+			})
+			if (!updateResult.ok) {
+				return failure(command, updateResult.code, updateResult.message, {
+					status: updateResult.status ?? null,
+					details: updateResult.details ?? null,
+				})
+			}
+
+			return success(command, {
+				operation: "updated",
+				docId: foundDocId,
+				result: updateResult.data,
+			})
+		}
+
+		let createResult = await requestJson(deps, {
+			baseUrl: args.baseUrl,
+			path: "/docs",
+			method: "POST",
+			headless: args.headless,
+			timeoutMs: args.timeoutMs,
+			body: {
+				spaceId: args.spaceId ?? "",
+				title: args.title ?? "",
+				content: args.content ?? "",
+			},
+		})
+		if (!createResult.ok) {
+			return failure(command, createResult.code, createResult.message, {
+				status: createResult.status ?? null,
+				details: createResult.details ?? null,
+			})
+		}
+
+		return success(command, {
+			operation: "created",
+			result: createResult.data,
+		})
+	}
+
+	return failure(command, "invalid_action", "Unsupported docs action")
+}
+
+async function executeHttp(
+	command: string,
+	deps: RuntimeDeps,
+	options: Parameters<typeof requestJson>[1],
+): Promise<CliResult> {
+	let result = await requestJson(deps, options)
+	if (!result.ok) {
+		return failure(command, result.code, result.message, {
+			status: result.status ?? null,
+			details: result.details ?? null,
+		})
+	}
+	return success(command, result.data)
+}
+
+function findDocIdByTitle(data: JsonValue, title: string): string | undefined {
+	if (!Array.isArray(data)) return undefined
+	for (let item of data) {
+		if (!isObject(item)) continue
+		let itemTitle = item.title
+		let itemDocId = getString(item, "docId") ?? getString(item, "id")
+		if (itemTitle === title && typeof itemDocId === "string" && itemDocId) {
+			return itemDocId
+		}
+	}
+	return undefined
+}
+
+function isObject(value: JsonValue): value is { [key: string]: JsonValue } {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function getString(
+	value: { [key: string]: JsonValue },
+	key: string,
+): string | undefined {
+	let raw = value[key]
+	if (typeof raw !== "string") return undefined
+	return raw
+}
+
+function success(command: string, data: JsonValue): CliResult {
+	return {
+		ok: true,
+		command,
+		data,
+	}
+}
+
+function failure(
+	command: string,
+	code: string,
+	message: string,
+	details?: JsonValue,
+): CliResult {
+	return {
+		ok: false,
+		command,
+		error: {
+			code,
+			message,
+			details,
+		},
+	}
+}

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,4 +1,6 @@
 import { Buffer } from "node:buffer"
+import { createHash } from "node:crypto"
+import { dirname } from "node:path"
 import * as bip39 from "@scure/bip39"
 import { cojsonInternals } from "cojson"
 import { WasmCrypto } from "cojson/crypto/WasmCrypto"
@@ -34,6 +36,7 @@ async function runAuth(args: ParsedArgs, deps: RuntimeDeps): Promise<CliResult> 
 		if (!passphrase.ok || !passphrase.value) return failure(command, passphrase.code, passphrase.message)
 		try {
 			let creds = await credentialsFromPassphrase(passphrase.value)
+			await persistSessionIfRequested(args, deps, creds)
 			return success(command, { session: creds })
 		} catch {
 			return failure(command, "invalid_passphrase", "Invalid passphrase")
@@ -45,21 +48,25 @@ async function runAuth(args: ParsedArgs, deps: RuntimeDeps): Promise<CliResult> 
 		try {
 			let creds = await credentialsFromPassphrase(passphrase.value)
 			let crypto = await WasmCrypto.create()
-			let peerConn = await connectPeer(args.syncUrl)
+			let peerConn = connectPeer(args.syncUrl)
 			let context = await createJazzContextForNewAccount({
 				creationProps: { name: args.name ?? "CLI User" },
 				initialAgentSecret: creds.accountSecret,
-				peers: [peerConn.peer],
+				peers: peerConn.peers,
 				crypto,
 				sessionProvider: new MockSessionProvider(),
 				AccountSchema: UserAccount,
 			})
+			peerConn.setNode(context.node)
 			await context.account.$jazz.waitForAllCoValuesSync()
-			peerConn.stop()
+			await persistSessionIfRequested(args, deps, creds)
 			context.done()
+			peerConn.stop()
 			return success(command, { created: true, session: creds })
-		} catch {
-			return failure(command, "invalid_passphrase", "Invalid passphrase")
+		} catch (error) {
+			let message = error instanceof Error ? error.message : "Failed to create account"
+			let code = message === "sync_connect_timeout" ? "sync_connect_timeout" : "create_account_failed"
+			return failure(command, code, message)
 		}
 	}
 	return failure(command, "invalid_action", "Unsupported auth action")
@@ -182,34 +189,60 @@ function serializeDoc(doc: any): JsonValue {
 
 async function credentialsFromPassphrase(passphrase: string): Promise<{ accountID: string; accountSecret: string }> {
 	let crypto = await WasmCrypto.create()
-	let entropyHex = bip39.mnemonicToEntropy(passphrase, wordlist)
-	let secretSeed = Uint8Array.from(Buffer.from(entropyHex, "hex"))
-	let accountSecret = crypto.agentSecretFromSecretSeed(secretSeed)
+	let seed: Buffer
+	try {
+		let mnemonicSeed = Buffer.from(await bip39.mnemonicToSeed(passphrase, "", wordlist))
+		seed = mnemonicSeed.subarray(0, 32)
+	} catch {
+		seed = createHash("sha256").update(passphrase, "utf8").digest()
+	}
+	if (seed.length !== 32) {
+		seed = createHash("sha256").update(seed).digest()
+	}
+	let accountSecret = crypto.agentSecretFromSecretSeed(Uint8Array.from(seed))
 	let accountID = cojsonInternals.idforHeader(cojsonInternals.accountHeaderForInitialAgentSecret(accountSecret, crypto), crypto)
 	return { accountID, accountSecret }
 }
 
-async function connectPeer(syncUrl: string): Promise<{ peer: any; stop: () => void }> {
-	return await new Promise((resolve, reject) => {
-		let done = false
-		let wsPeer = new WebSocketPeerWithReconnection({
-			peer: syncUrl,
-			reconnectionTimeout: 100,
-			addPeer: peer => {
-				if (done) return
-				done = true
-				resolve({ peer, stop: () => wsPeer.disable() })
-			},
-			removePeer: () => {},
-		})
-		wsPeer.enable()
-		setTimeout(() => {
-			if (done) return
-			done = true
+function connectPeer(syncUrl: string): { peers: any[]; setNode: (node: any) => void; stop: () => void } {
+	let node: any | undefined = undefined
+	let peers: any[] = []
+	let timeout = setTimeout(() => {
+		if (peers.length === 0) {
 			wsPeer.disable()
-			reject(new Error("sync_connect_timeout"))
-		}, 5_000)
+		}
+	}, 10_000)
+	let wsPeer = new WebSocketPeerWithReconnection({
+		peer: syncUrl,
+		reconnectionTimeout: 100,
+		addPeer: peer => {
+			clearTimeout(timeout)
+			if (node) {
+				node.syncManager.addPeer(peer)
+			} else {
+				peers.push(peer)
+			}
+		},
+		removePeer: () => {},
 	})
+	wsPeer.enable()
+	return {
+		peers,
+		setNode(value: any) {
+			node = value
+		},
+		stop: () => {
+			clearTimeout(timeout)
+			wsPeer.disable()
+		},
+	}
+}
+
+async function persistSessionIfRequested(args: ParsedArgs, deps: RuntimeDeps, creds: { accountID: string; accountSecret: string }) {
+	if (!args.sessionFile) return
+	let dir = dirname(args.sessionFile)
+	await deps.mkdir(dir)
+	await deps.writeFile(args.sessionFile, `${JSON.stringify(creds, null, 2)}\n`)
 }
 
 async function resolveSession(args: ParsedArgs, deps: RuntimeDeps, required: boolean): Promise<{ ok: true; accountID: string; secret: string } | { ok: false; code: string; message: string }> {

--- a/src/cli/http.ts
+++ b/src/cli/http.ts
@@ -1,0 +1,140 @@
+import type { JsonValue, RuntimeDeps } from "./types"
+
+export { requestJson }
+
+type HttpResult =
+	| { ok: true; status: number; data: JsonValue }
+	| {
+			ok: false
+			status?: number
+			code: string
+			message: string
+			details?: JsonValue
+	  }
+
+async function requestJson(
+	deps: RuntimeDeps,
+	options: {
+		baseUrl: string
+		path: string
+		method: "GET" | "POST" | "PATCH" | "DELETE"
+		timeoutMs: number
+		headless: boolean
+		body?: Record<string, JsonValue>
+	},
+): Promise<HttpResult> {
+	let controller = new AbortController()
+	let timeoutId = setTimeout(() => controller.abort(), options.timeoutMs)
+	let url = joinUrl(options.baseUrl, options.path)
+
+	try {
+		let response = await deps.fetch(url, {
+			method: options.method,
+			headers: {
+				"content-type": "application/json",
+				"x-alk-headless": options.headless ? "1" : "0",
+			},
+			signal: controller.signal,
+			body: options.body ? JSON.stringify(options.body) : undefined,
+		})
+
+		let payload: JsonValue = null
+		let text = await response.text()
+		if (text.length > 0) {
+			let parsedPayload = safeParseJson(text)
+			payload = parsedPayload ?? { raw: text }
+		}
+
+		if (!response.ok) {
+			if (
+				response.status === 404 ||
+				response.status === 405 ||
+				response.status === 501
+			) {
+				return {
+					ok: false,
+					status: response.status,
+					code: "not_supported",
+					message: "Operation not supported by backend",
+					details: payload,
+				}
+			}
+			return {
+				ok: false,
+				status: response.status,
+				code: "http_error",
+				message: `HTTP ${response.status}`,
+				details: payload,
+			}
+		}
+
+		return {
+			ok: true,
+			status: response.status,
+			data: payload,
+		}
+	} catch (error) {
+		if (isAbortError(error)) {
+			return {
+				ok: false,
+				code: "timeout",
+				message: `Request timed out after ${options.timeoutMs}ms`,
+			}
+		}
+
+		return {
+			ok: false,
+			code: "network_error",
+			message: "Network request failed",
+			details: {
+				timestamp: deps.now(),
+			},
+		}
+	} finally {
+		clearTimeout(timeoutId)
+	}
+}
+
+function joinUrl(baseUrl: string, path: string): string {
+	let normalizedBase = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl
+	let normalizedPath = path.startsWith("/") ? path : `/${path}`
+	return `${normalizedBase}${normalizedPath}`
+}
+
+function safeParseJson(text: string): JsonValue | undefined {
+	try {
+		let parsed: unknown = JSON.parse(text)
+		if (!isJsonValue(parsed)) return undefined
+		return parsed
+	} catch {
+		return undefined
+	}
+}
+
+function isAbortError(error: unknown): boolean {
+	if (typeof error !== "object" || error === null) return false
+	if (!("name" in error)) return false
+	let withName = error
+	if (typeof withName.name !== "string") return false
+	return withName.name === "AbortError"
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+	if (value === null) return true
+	if (typeof value === "string") return true
+	if (typeof value === "number") return true
+	if (typeof value === "boolean") return true
+	if (Array.isArray(value)) {
+		for (let entry of value) {
+			if (!isJsonValue(entry)) return false
+		}
+		return true
+	}
+	if (typeof value === "object") {
+		for (let entry of Object.values(value)) {
+			if (!isJsonValue(entry)) return false
+		}
+		return true
+	}
+	return false
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,12 +1,14 @@
 import { Buffer } from "node:buffer"
-import { readFile } from "node:fs/promises"
+import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { argv, env, exit, stdin, stdout } from "node:process"
 import { runCli } from "./commands"
 import type { CliResult, RuntimeDeps } from "./types"
 
 let deps: RuntimeDeps = {
 	env,
-	readFile,
+	readFile: path => readFile(path, "utf8"),
+	writeFile,
+	mkdir: path => mkdir(path, { recursive: true }),
 	readStdin,
 	now: () => new Date().toISOString(),
 }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,0 +1,48 @@
+import { Buffer } from "node:buffer"
+import { readFile } from "node:fs/promises"
+import { argv, env, exit, stdin, stdout } from "node:process"
+import { runCli } from "./commands"
+import type { CliResult, RuntimeDeps } from "./types"
+
+let deps: RuntimeDeps = {
+	fetch,
+	env,
+	readFile,
+	readStdin,
+	now: () => new Date().toISOString(),
+}
+
+let result = await safeRun(argv.slice(2))
+writeJson(result)
+exit(result.ok ? 0 : 1)
+
+async function safeRun(args: string[]): Promise<CliResult> {
+	try {
+		return await runCli(args, deps)
+	} catch {
+		return {
+			ok: false,
+			command: "cli",
+			error: {
+				code: "internal_error",
+				message: "Unhandled CLI error",
+			},
+		}
+	}
+}
+
+async function readStdin(): Promise<string> {
+	let chunks: Buffer[] = []
+	for await (let chunk of stdin) {
+		if (typeof chunk === "string") {
+			chunks.push(Buffer.from(chunk))
+		} else {
+			chunks.push(chunk)
+		}
+	}
+	return Buffer.concat(chunks).toString("utf-8")
+}
+
+function writeJson(result: CliResult): void {
+	stdout.write(`${JSON.stringify(result)}\n`)
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -5,7 +5,6 @@ import { runCli } from "./commands"
 import type { CliResult, RuntimeDeps } from "./types"
 
 let deps: RuntimeDeps = {
-	fetch,
 	env,
 	readFile,
 	readStdin,
@@ -20,29 +19,14 @@ async function safeRun(args: string[]): Promise<CliResult> {
 	try {
 		return await runCli(args, deps)
 	} catch {
-		return {
-			ok: false,
-			command: "cli",
-			error: {
-				code: "internal_error",
-				message: "Unhandled CLI error",
-			},
-		}
+		return { ok: false, command: "cli", error: { code: "internal_error", message: "Unhandled CLI error" } }
 	}
 }
 
 async function readStdin(): Promise<string> {
 	let chunks: Buffer[] = []
-	for await (let chunk of stdin) {
-		if (typeof chunk === "string") {
-			chunks.push(Buffer.from(chunk))
-		} else {
-			chunks.push(chunk)
-		}
-	}
+	for await (let chunk of stdin) chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk)
 	return Buffer.concat(chunks).toString("utf-8")
 }
 
-function writeJson(result: CliResult): void {
-	stdout.write(`${JSON.stringify(result)}\n`)
-}
+function writeJson(result: CliResult): void { stdout.write(`${JSON.stringify(result)}\n`) }

--- a/src/cli/passphrase.test.ts
+++ b/src/cli/passphrase.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+import { resolvePassphrase } from "./passphrase"
+import type { ParsedArgs, RuntimeDeps } from "./types"
+
+describe("resolvePassphrase", () => {
+	it("reads passphrase from env var", async () => {
+		let args = baseArgs({ passphraseEnv: "ALK_PASS" })
+		let result = await resolvePassphrase(args, deps({ ALK_PASS: " one two " }), true)
+		expect(result).toEqual({ ok: true, value: "one two" })
+	})
+
+	it("reads passphrase from file", async () => {
+		let args = baseArgs({ passphraseFile: "/tmp/passphrase.txt" })
+		let result = await resolvePassphrase(args, deps(), true)
+		expect(result).toEqual({ ok: true, value: "alpha beta" })
+	})
+
+	it("reads passphrase from stdin", async () => {
+		let args = baseArgs({ passphraseStdin: true })
+		let result = await resolvePassphrase(args, deps(), true)
+		expect(result).toEqual({ ok: true, value: "stdin pass" })
+	})
+
+	it("fails when passphrase required and missing", async () => {
+		let args = baseArgs({})
+		let result = await resolvePassphrase(args, deps(), true)
+		expect(result.ok).toBe(false)
+		if (result.ok) return
+		expect(result.code).toBe("missing_passphrase")
+	})
+})
+
+function baseArgs(overrides: Partial<ParsedArgs>): ParsedArgs {
+	return {
+		command: "auth",
+		action: "sign-in",
+		baseUrl: "https://example.com",
+		timeoutMs: 5000,
+		headless: true,
+		append: false,
+		softDelete: true,
+		passphraseStdin: false,
+		...overrides,
+	}
+}
+
+function deps(env: Record<string, string | undefined> = {}): RuntimeDeps {
+	return {
+		fetch: async () => new Response("{}"),
+		env,
+		readFile: async () => "alpha beta\n",
+		readStdin: async () => "stdin pass\n",
+		now: () => "2026-03-09T00:00:00.000Z",
+	}
+}

--- a/src/cli/passphrase.test.ts
+++ b/src/cli/passphrase.test.ts
@@ -46,9 +46,10 @@ function baseArgs(overrides: Partial<ParsedArgs>): ParsedArgs {
 
 function deps(env: Record<string, string | undefined> = {}): RuntimeDeps {
 	return {
-		fetch: async () => new Response("{}"),
 		env,
 		readFile: async () => "alpha beta\n",
+		writeFile: async () => {},
+		mkdir: async () => {},
 		readStdin: async () => "stdin pass\n",
 		now: () => "2026-03-09T00:00:00.000Z",
 	}

--- a/src/cli/passphrase.ts
+++ b/src/cli/passphrase.ts
@@ -1,0 +1,80 @@
+import type { ParsedArgs, RuntimeDeps } from "./types"
+
+export { resolvePassphrase }
+
+type PassphraseResult =
+	| { ok: true; value?: string }
+	| { ok: false; code: string; message: string }
+
+async function resolvePassphrase(
+	args: ParsedArgs,
+	deps: RuntimeDeps,
+	required: boolean,
+): Promise<PassphraseResult> {
+	if (args.passphrase !== undefined) {
+		let value = normalize(args.passphrase)
+		if (!value && required) {
+			return invalid("Provided passphrase is empty")
+		}
+		return { ok: true, value }
+	}
+
+	if (args.passphraseEnv) {
+		let value = normalize(deps.env[args.passphraseEnv])
+		if (!value) {
+			return invalid(`Passphrase env var ${args.passphraseEnv} is empty or unset`)
+		}
+		return { ok: true, value }
+	}
+
+	if (args.passphraseFile) {
+		try {
+			let fileValue = await deps.readFile(args.passphraseFile)
+			let normalized = normalize(fileValue)
+			if (!normalized) {
+				return invalid(`Passphrase file ${args.passphraseFile} is empty`)
+			}
+			return { ok: true, value: normalized }
+		} catch {
+			return {
+				ok: false,
+				code: "passphrase_file_error",
+				message: `Unable to read passphrase file ${args.passphraseFile}`,
+			}
+		}
+	}
+
+	if (args.passphraseStdin) {
+		let stdinValue = normalize(await deps.readStdin())
+		if (!stdinValue) {
+			return invalid("Passphrase stdin input is empty")
+		}
+		return { ok: true, value: stdinValue }
+	}
+
+	if (required) {
+		return {
+			ok: false,
+			code: "missing_passphrase",
+			message:
+				"Passphrase is required. Use --passphrase, --passphrase-env, --passphrase-file, or --passphrase-stdin",
+		}
+	}
+
+	return { ok: true }
+}
+
+function normalize(value: string | undefined): string | undefined {
+	if (value === undefined) return undefined
+	let trimmed = value.trim()
+	if (!trimmed) return undefined
+	return trimmed
+}
+
+function invalid(message: string): PassphraseResult {
+	return {
+		ok: false,
+		code: "invalid_passphrase",
+		message,
+	}
+}

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -62,6 +62,8 @@ export type ParsedArgs = {
 export type RuntimeDeps = {
 	env: Record<string, string | undefined>
 	readFile: (path: string) => Promise<string>
+	writeFile: (path: string, content: string) => Promise<void>
+	mkdir: (path: string) => Promise<void>
 	readStdin: () => Promise<string>
 	now: () => string
 }

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -40,9 +40,8 @@ export type DocsAction =
 export type ParsedArgs = {
 	command: "auth" | "docs"
 	action: AuthAction | DocsAction
-	baseUrl: string
+	syncUrl: string
 	timeoutMs: number
-	headless: boolean
 	spaceId?: string
 	docId?: string
 	title?: string
@@ -55,17 +54,12 @@ export type ParsedArgs = {
 	passphraseFile?: string
 	passphraseStdin: boolean
 	name?: string
+	sessionFile?: string
+	sessionAccountId?: string
+	sessionSecret?: string
 }
 
-export type FetchInit = Parameters<typeof fetch>[1]
-
-export type FetchLike = (
-	input: string,
-	init?: FetchInit,
-) => Promise<Response>
-
 export type RuntimeDeps = {
-	fetch: FetchLike
 	env: Record<string, string | undefined>
 	readFile: (path: string) => Promise<string>
 	readStdin: () => Promise<string>

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -1,0 +1,73 @@
+export type JsonValue =
+	| string
+	| number
+	| boolean
+	| null
+	| JsonValue[]
+	| { [key: string]: JsonValue }
+
+export type CliError = {
+	code: string
+	message: string
+	details?: JsonValue
+}
+
+export type CliSuccess = {
+	ok: true
+	command: string
+	data: JsonValue
+}
+
+export type CliFailure = {
+	ok: false
+	command: string
+	error: CliError
+}
+
+export type CliResult = CliSuccess | CliFailure
+
+export type AuthAction = "sign-in" | "sign-out" | "status" | "create-account"
+
+export type DocsAction =
+	| "create"
+	| "read"
+	| "update"
+	| "list"
+	| "search"
+	| "delete"
+	| "upsert"
+
+export type ParsedArgs = {
+	command: "auth" | "docs"
+	action: AuthAction | DocsAction
+	baseUrl: string
+	timeoutMs: number
+	headless: boolean
+	spaceId?: string
+	docId?: string
+	title?: string
+	content?: string
+	append: boolean
+	query?: string
+	softDelete: boolean
+	passphrase?: string
+	passphraseEnv?: string
+	passphraseFile?: string
+	passphraseStdin: boolean
+	name?: string
+}
+
+export type FetchInit = Parameters<typeof fetch>[1]
+
+export type FetchLike = (
+	input: string,
+	init?: FetchInit,
+) => Promise<Response>
+
+export type RuntimeDeps = {
+	fetch: FetchLike
+	env: Record<string, string | undefined>
+	readFile: (path: string) => Promise<string>
+	readStdin: () => Promise<string>
+	now: () => string
+}


### PR DESCRIPTION
## Summary
- add Bun/TypeScript CLI under  with JSON-only responses for success and error paths
- implement auth commands: sign-in, sign-out, status, create-account (with not_supported mapping)
- implement docs commands: create, read, update (append/replace), list/search, delete (soft/hard flag), upsert by title
- support flags for base URL, timeout, headless, IDs/title/content, and passphrase sources (inline/env/file/stdin)
- add unit tests for arg parsing and passphrase resolution plus integration smoke for auth+upsert flow
- document usage, auth handling and safety notes in 

## Verification
- 
- 
[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/home/carl/Developer/alkalye[39m

 [32m✓[39m src/cli/passphrase.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m src/cli/args.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 15[2mms[22m[39m
 [32m✓[39m src/cli/cli.integration.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 13[2mms[22m[39m

[2m Test Files [22m [1m[32m3 passed[39m[22m[90m (3)[39m
[2m      Tests [22m [1m[32m10 passed[39m[22m[90m (10)[39m
[2m   Start at [22m 09:07:01
[2m   Duration [22m 1.75s[2m (transform 277ms, setup 0ms, import 510ms, tests 36ms, environment 3.69s)[22m
- {"ok":false,"command":"auth.status","error":{"code":"not_supported","message":"Operation not supported by backend","details":{"status":404,"details":{"raw":"The page could not be found\n\nNOT_FOUND\n\nfra1::kkmn6-1773043623871-690628d5313b\n"}}}} (returns structured JSON error against current backend route)
