### PR TITLE
Fix image drag-and-drop in editor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-PUBLIC_JAZZ_SYNC_SERVER=ws://localhost:4200
+PUBLIC_JAZZ_SYNC_SERVER=wss://alkalye-sync.localhost

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ test-results
 example
 .claude
 .vercel
+agents

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 src/app/routeTree.gen.ts
 test-results
+agents

--- a/bun.lock
+++ b/bun.lock
@@ -87,6 +87,7 @@
         "globals": "^17.1.0",
         "happy-dom": "^20.3.7",
         "jsdom": "^27.4.0",
+        "portless": "^0.12.0",
         "prettier": "^3.8.1",
         "prettier-plugin-tailwindcss": "^0.7.2",
         "typescript": "~5.9.3",
@@ -2171,6 +2172,8 @@
     "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
 
     "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
+
+    "portless": ["portless@0.12.0", "", { "os": [ "linux", "win32", "darwin", ], "bin": { "portless": "dist/cli.js" } }, "sha512-zE8EYJ5xIEtKEBu1wnD+FavOE90/GNxRixF4Mu2hxMvDuVx1ftUbA6VbjbxI9sP9LUt0L26l6OiENGo4EFtLfw=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -70,6 +70,7 @@ export default [
 			".astro/",
 			"eslint-local-rules/",
 			".vercel/",
+			".claude/",
 		],
 	},
 ]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
 	"version": "0.0.1",
 	"type": "module",
 	"scripts": {
-		"dev": "astro dev",
+		"dev": "portless run astro dev",
+		"dev:sync": "portless alkalye-sync sh -c 'bunx jazz-run sync --port \"$PORT\" --host \"$HOST\"'",
 		"build": "astro check && astro build",
 		"check": "bun x concurrently \"bun run check:lint\" \"bun run check:types\" \"bun run check:format\" \"bun run check:test\"",
 		"check:lint": "eslint .",
@@ -111,6 +112,7 @@
 		"globals": "^17.1.0",
 		"happy-dom": "^20.3.7",
 		"jsdom": "^27.4.0",
+		"portless": "^0.12.0",
 		"prettier": "^3.8.1",
 		"prettier-plugin-tailwindcss": "^0.7.2",
 		"typescript": "~5.9.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig, devices } from "@playwright/test"
 
-let port = Number.parseInt(process.env.PLAYWRIGHT_PORT ?? "4173", 10)
-let baseUrl = `http://127.0.0.1:${port}`
+let appUrl = "https://alkalye-e2e.localhost"
+let syncUrl = "https://alkalye-sync-e2e.localhost"
 
 export default defineConfig({
 	testDir: "./e2e",
@@ -13,7 +13,8 @@ export default defineConfig({
 	retries: process.env.CI ? 2 : 0,
 	reporter: "list",
 	use: {
-		baseURL: baseUrl,
+		baseURL: appUrl,
+		ignoreHTTPSErrors: true,
 		trace: "on-first-retry",
 		permissions: ["clipboard-read", "clipboard-write"],
 	},
@@ -23,10 +24,21 @@ export default defineConfig({
 			use: { ...devices["Desktop Chrome"] },
 		},
 	],
-	webServer: {
-		command: `sh -c 'if ! lsof -iTCP:4200 -sTCP:LISTEN >/dev/null 2>&1; then bunx jazz-run sync --in-memory & fi; bun run dev --host 127.0.0.1 --port ${port}'`,
-		url: `${baseUrl}/app`,
-		reuseExistingServer: !process.env.CI,
-		timeout: 120_000,
-	},
+	webServer: [
+		{
+			command: `portless alkalye-sync-e2e sh -c 'bunx jazz-run sync --in-memory --port "$PORT" --host "$HOST"'`,
+			url: syncUrl,
+			reuseExistingServer: !process.env.CI,
+			ignoreHTTPSErrors: true,
+			timeout: 60_000,
+		},
+		{
+			command: `portless alkalye-e2e astro dev`,
+			url: `${appUrl}/app`,
+			env: { PUBLIC_JAZZ_SYNC_SERVER: syncUrl.replace(/^https/, "wss") },
+			reuseExistingServer: !process.env.CI,
+			ignoreHTTPSErrors: true,
+			timeout: 120_000,
+		},
+	],
 })

--- a/portless.json
+++ b/portless.json
@@ -1,0 +1,3 @@
+{
+	"name": "alkalye"
+}

--- a/solo.yml
+++ b/solo.yml
@@ -23,7 +23,7 @@ processes:
     restart_when_changed: []
     env: {}
   Jazz Sync Server:
-    command: bunx jazz-run sync
+    command: bun run dev:sync
     working_dir: null
     auto_start: true
     auto_restart: false

--- a/src/app/routes/doc.$id.index.tsx
+++ b/src/app/routes/doc.$id.index.tsx
@@ -490,6 +490,7 @@ function EditorContent({ doc, docId }: EditorContentProps) {
 					remoteCursors={remoteCursors}
 					onCreateDocument={makeCreateDocument(me)}
 					onUploadImage={makeUploadImage(doc)}
+					onUploadVideo={canUploadVideo ? makeUploadVideo(doc) : undefined}
 					autoSortTasks={editorSettings?.editor?.autoSortTasks}
 				/>
 				<EditorToolbar

--- a/src/app/routes/spaces.$spaceId.doc.$id.index.tsx
+++ b/src/app/routes/spaces.$spaceId.doc.$id.index.tsx
@@ -497,6 +497,7 @@ function SpaceEditorContent({
 					remoteCursors={remoteCursors}
 					onCreateDocument={makeCreateDocument(space)}
 					onUploadImage={makeUploadImage(doc)}
+					onUploadVideo={canUploadVideo ? makeUploadVideo(doc) : undefined}
 					autoSortTasks={editorSettings?.editor?.autoSortTasks}
 				/>
 				<EditorToolbar

--- a/src/editor/editor.tsx
+++ b/src/editor/editor.tsx
@@ -81,6 +81,10 @@ import {
 	WikiLinkAction,
 	type FloatingActionsRef,
 } from "@/components/floating-actions"
+import {
+	UploadProgressDialog,
+	type UploadPhase,
+} from "@/components/upload-progress-dialog"
 
 export { MarkdownEditor, useMarkdownEditorRef }
 export { parseFrontmatter } from "./frontmatter"
@@ -131,12 +135,26 @@ interface MarkdownEditorProps {
 	// Callbacks (optional = feature detection)
 	onCreateDocument?: (title: string) => Promise<string>
 	onUploadImage?: (file: File) => Promise<{ id: string; name: string }>
+	onUploadVideo?: (
+		file: File,
+		options: {
+			onProgress: (p: { phase: UploadPhase; progress: number }) => void
+			signal: AbortSignal
+		},
+	) => Promise<{ id: string; name: string }>
 
 	// Config
 	placeholder?: string
 	readOnly?: boolean
 	className?: string
 	autoSortTasks?: boolean
+}
+
+type VideoUploadState = {
+	fileName: string
+	phase: UploadPhase
+	progress: number
+	abortController: AbortController
 }
 
 interface MarkdownEditorRef {
@@ -206,6 +224,7 @@ function MarkdownEditor(
 		remoteCursors,
 		onCreateDocument,
 		onUploadImage,
+		onUploadVideo,
 		placeholder,
 		readOnly,
 		className,
@@ -234,12 +253,14 @@ function MarkdownEditor(
 		alt: string
 		assetId: string | null
 	} | null>(null)
+	let [videoUpload, setVideoUpload] = useState<VideoUploadState | null>(null)
 
 	let callbacksRef = useRef({ onChange, onCursorChange, onFocus, onBlur })
 	findPanelOpenRef.current = findPanelOpen
 	let dataRef = useRef({ assets, documents })
 	let autoSortRef = useRef(autoSortTasks ?? false)
 	let uploadImageRef = useRef(onUploadImage)
+	let uploadVideoRef = useRef(onUploadVideo)
 	let activeDropsRef = useRef<Set<DropTarget>>(new Set())
 
 	useEffect(() => {
@@ -248,6 +269,10 @@ function MarkdownEditor(
 
 	useEffect(() => {
 		uploadImageRef.current = onUploadImage
+	})
+
+	useEffect(() => {
+		uploadVideoRef.current = onUploadVideo
 	})
 
 	useEffect(() => {
@@ -542,39 +567,83 @@ function MarkdownEditor(
 			let files = event.dataTransfer?.files
 			if (!files || files.length === 0) return
 
-			// Always preventDefault on file drops so non-image files
-			// (PDFs, videos, etc) don't fall through to file:// navigation.
+			// Always preventDefault on file drops so unsupported files
+			// (PDFs, etc) don't fall through to file:// navigation.
 			event.preventDefault()
 			event.stopPropagation()
 
 			if (!view || view.state.readOnly) return
-			let upload = uploadImageRef.current
-			if (!upload) return
+			let activeView = view
+			let uploadImage = uploadImageRef.current
+			let uploadVideo = uploadVideoRef.current
 
-			let images = Array.from(files).filter(f => f.type.startsWith("image/"))
-			if (images.length === 0) return
+			let images = uploadImage
+				? Array.from(files).filter(f => f.type.startsWith("image/"))
+				: []
+			let videos = uploadVideo
+				? Array.from(files).filter(f => f.type.startsWith("video/"))
+				: []
+			if (images.length === 0 && videos.length === 0) return
 
 			let dropPos =
-				view.posAtCoords({ x: event.clientX, y: event.clientY }) ??
-				view.state.doc.length
+				activeView.posAtCoords({ x: event.clientX, y: event.clientY }) ??
+				activeView.state.doc.length
 			let target: DropTarget = { pos: dropPos }
 			activeDropsRef.current.add(target)
 
+			function insertAtTarget(text: string) {
+				if (!activeView.contentDOM.isConnected) return
+				let pos = Math.max(
+					0,
+					Math.min(target.pos, activeView.state.doc.length),
+				)
+				activeView.dispatch({
+					changes: { from: pos, insert: text },
+					selection: { anchor: pos + text.length },
+				})
+			}
+
 			void (async () => {
 				try {
-					for (let file of images) {
-						try {
-							let result = await upload(file)
-							if (!view.contentDOM.isConnected) return
-							let text = `![${result.name}](asset:${result.id})`
-							let pos = Math.max(0, Math.min(target.pos, view.state.doc.length))
-							view.dispatch({
-								changes: { from: pos, insert: text },
-								selection: { anchor: pos + text.length },
+					if (uploadImage) {
+						for (let file of images) {
+							try {
+								let result = await uploadImage(file)
+								insertAtTarget(`![${result.name}](asset:${result.id})`)
+							} catch (err) {
+								console.error("Image upload failed:", err)
+								toast.error(`Failed to upload ${file.name}`)
+							}
+						}
+					}
+					if (uploadVideo) {
+						for (let file of videos) {
+							let abortController = new AbortController()
+							setVideoUpload({
+								fileName: file.name,
+								phase: "compressing",
+								progress: 0,
+								abortController,
 							})
-						} catch (err) {
-							console.error("Image upload failed:", err)
-							toast.error(`Failed to upload ${file.name}`)
+							try {
+								let result = await uploadVideo(file, {
+									onProgress: p =>
+										setVideoUpload(prev =>
+											prev
+												? { ...prev, phase: p.phase, progress: p.progress }
+												: null,
+										),
+									signal: abortController.signal,
+								})
+								insertAtTarget(`![${result.name}](asset:${result.id})`)
+							} catch (err) {
+								if (!abortController.signal.aborted) {
+									console.error("Video upload failed:", err)
+									toast.error(`Failed to upload ${file.name}`)
+								}
+							} finally {
+								setVideoUpload(null)
+							}
 						}
 					}
 				} finally {
@@ -948,6 +1017,19 @@ function MarkdownEditor(
 					</>
 				)}
 			</FloatingActions>
+
+			{videoUpload && (
+				<UploadProgressDialog
+					open={true}
+					fileName={videoUpload.fileName}
+					phase={videoUpload.phase}
+					progress={videoUpload.progress}
+					onCancel={() => {
+						videoUpload.abortController.abort()
+						setVideoUpload(null)
+					}}
+				/>
+			)}
 
 			<Dialog
 				open={mediaPreviewOpen}

--- a/src/editor/editor.tsx
+++ b/src/editor/editor.tsx
@@ -235,9 +235,14 @@ function MarkdownEditor(
 	findPanelOpenRef.current = findPanelOpen
 	let dataRef = useRef({ assets, documents })
 	let autoSortRef = useRef(autoSortTasks ?? false)
+	let uploadImageRef = useRef(onUploadImage)
 
 	useEffect(() => {
 		callbacksRef.current = { onChange, onCursorChange, onFocus, onBlur }
+	})
+
+	useEffect(() => {
+		uploadImageRef.current = onUploadImage
 	})
 
 	useEffect(() => {
@@ -506,6 +511,54 @@ function MarkdownEditor(
 			dispatchRemoteCursors(view, remoteCursors)
 		}
 	}, [view, remoteCursors])
+
+	useEffect(() => {
+		let dom = containerRef.current
+		if (!dom || !view) return
+
+		function isFileDrag(event: DragEvent) {
+			return event.dataTransfer?.types.includes("Files") ?? false
+		}
+
+		function handleDragOver(event: DragEvent) {
+			if (isFileDrag(event)) event.preventDefault()
+		}
+
+		function handleDrop(event: DragEvent) {
+			let files = event.dataTransfer?.files
+			if (!files || files.length === 0) return
+			let images = Array.from(files).filter(f => f.type.startsWith("image/"))
+			if (images.length === 0) return
+
+			event.preventDefault()
+			let upload = uploadImageRef.current
+			if (!upload || !view) return
+
+			let dropPos =
+				view.posAtCoords({ x: event.clientX, y: event.clientY }) ??
+				view.state.selection.main.head
+
+			void (async () => {
+				let pos = dropPos
+				for (let file of images) {
+					let result = await upload(file)
+					let text = `![${result.name}](asset:${result.id})`
+					view.dispatch({
+						changes: { from: pos, insert: text },
+						selection: { anchor: pos + text.length },
+					})
+					pos += text.length
+				}
+			})()
+		}
+
+		dom.addEventListener("dragover", handleDragOver)
+		dom.addEventListener("drop", handleDrop)
+		return () => {
+			dom.removeEventListener("dragover", handleDragOver)
+			dom.removeEventListener("drop", handleDrop)
+		}
+	}, [view])
 
 	useEffect(() => {
 		if (!view) return

--- a/src/editor/editor.tsx
+++ b/src/editor/editor.tsx
@@ -63,6 +63,7 @@ import { createBacklinkDecorations } from "./backlink-decorations"
 import { createImageDecorations } from "./image-decorations"
 import { findExtension, selectMatch } from "./find-extension"
 import { FindPanel } from "./find-panel"
+import { fileDropCursor } from "./file-drop-cursor"
 
 import { useIsMobile } from "@/lib/use-mobile"
 import { useFindPanel } from "@/hooks/use-find-panel"
@@ -486,6 +487,7 @@ function MarkdownEditor(
 			),
 			createImageDecorations(imageResolver, handleImagePreview),
 			findExtension,
+			fileDropCursor(),
 		]
 
 		if (initRef.current.placeholder) {

--- a/src/editor/editor.tsx
+++ b/src/editor/editor.tsx
@@ -102,6 +102,8 @@ type RemoteCursor = {
 	selectionEnd?: number
 }
 
+type DropTarget = { pos: number }
+
 type Asset = {
 	id: string
 	name: string
@@ -238,7 +240,7 @@ function MarkdownEditor(
 	let dataRef = useRef({ assets, documents })
 	let autoSortRef = useRef(autoSortTasks ?? false)
 	let uploadImageRef = useRef(onUploadImage)
-	let activeDropsRef = useRef<Set<{ pos: number }>>(new Set())
+	let activeDropsRef = useRef<Set<DropTarget>>(new Set())
 
 	useEffect(() => {
 		callbacksRef.current = { onChange, onCursorChange, onFocus, onBlur }
@@ -452,11 +454,11 @@ function MarkdownEditor(
 					if (callbacksRef.current.onChange) {
 						callbacksRef.current.onChange(update.state.doc.toString())
 					}
-					// Map drop targets through any concurrent transaction so
-					// images dropped while another upload is awaiting still
-					// land at the intended position.
-					for (let drop of activeDropsRef.current) {
-						drop.pos = update.changes.mapPos(drop.pos, 1)
+					// Keep in-flight drop targets aligned with the live doc so
+					// images dropped while uploads await still land at the
+					// originally-pointed position.
+					for (let target of activeDropsRef.current) {
+						target.pos = update.changes.mapPos(target.pos, 1)
 					}
 				}
 				if (update.selectionSet && callbacksRef.current.onCursorChange) {
@@ -487,7 +489,7 @@ function MarkdownEditor(
 			),
 			createImageDecorations(imageResolver, handleImagePreview),
 			findExtension,
-			fileDropCursor(),
+			fileDropCursor,
 		]
 
 		if (initRef.current.placeholder) {
@@ -555,8 +557,8 @@ function MarkdownEditor(
 			let dropPos =
 				view.posAtCoords({ x: event.clientX, y: event.clientY }) ??
 				view.state.doc.length
-			let drop = { pos: dropPos }
-			activeDropsRef.current.add(drop)
+			let target: DropTarget = { pos: dropPos }
+			activeDropsRef.current.add(target)
 
 			void (async () => {
 				try {
@@ -565,8 +567,7 @@ function MarkdownEditor(
 							let result = await upload(file)
 							if (!view.contentDOM.isConnected) return
 							let text = `![${result.name}](asset:${result.id})`
-							let docLength = view.state.doc.length
-							let pos = Math.max(0, Math.min(drop.pos, docLength))
+							let pos = Math.max(0, Math.min(target.pos, view.state.doc.length))
 							view.dispatch({
 								changes: { from: pos, insert: text },
 								selection: { anchor: pos + text.length },
@@ -577,7 +578,7 @@ function MarkdownEditor(
 						}
 					}
 				} finally {
-					activeDropsRef.current.delete(drop)
+					activeDropsRef.current.delete(target)
 				}
 			})()
 		}

--- a/src/editor/editor.tsx
+++ b/src/editor/editor.tsx
@@ -15,7 +15,6 @@ import {
 	keymap,
 	placeholder as placeholderExt,
 	highlightActiveLine,
-	dropCursor,
 } from "@codemirror/view"
 import {
 	deleteMarkupBackward,
@@ -446,7 +445,6 @@ function MarkdownEditor(
 			}),
 			editorExtensions,
 			highlightActiveLine(),
-			dropCursor(),
 			EditorView.lineWrapping,
 			EditorView.updateListener.of(update => {
 				if (update.docChanged) {
@@ -532,39 +530,8 @@ function MarkdownEditor(
 			return event.dataTransfer?.types.includes("Files") ?? false
 		}
 
-		// CodeMirror's dropCursor observer is attached to .cm-content, so it
-		// never fires when the drag is over .cm-scroller whitespace. Forward
-		// synthetic events on .cm-content so the cursor still shows and clears.
-		function forwardToContentDOM(type: string, event: DragEvent) {
-			if (!view) return
-			view.contentDOM.dispatchEvent(
-				new DragEvent(type, {
-					bubbles: false,
-					cancelable: true,
-					clientX: event.clientX,
-					clientY: event.clientY,
-				}),
-			)
-		}
-
 		function handleDragOver(event: DragEvent) {
-			if (!isFileDrag(event)) return
-			event.preventDefault()
-			if (
-				view &&
-				event.target instanceof Node &&
-				!view.contentDOM.contains(event.target)
-			) {
-				forwardToContentDOM("dragover", event)
-			}
-		}
-
-		function handleDragLeave(event: DragEvent) {
-			if (!isFileDrag(event) || !dom) return
-			let related = event.relatedTarget
-			let leaving =
-				!related || (related instanceof Node && !dom.contains(related))
-			if (leaving) forwardToContentDOM("dragend", event)
+			if (isFileDrag(event)) event.preventDefault()
 		}
 
 		function handleDrop(event: DragEvent) {
@@ -575,7 +542,6 @@ function MarkdownEditor(
 			// (PDFs, videos, etc) don't fall through to file:// navigation.
 			event.preventDefault()
 			event.stopPropagation()
-			forwardToContentDOM("dragend", event)
 
 			if (!view || view.state.readOnly) return
 			let upload = uploadImageRef.current
@@ -617,11 +583,9 @@ function MarkdownEditor(
 		// Capture phase so our preventDefault runs before CodeMirror's
 		// own drop handler on .cm-content.
 		dom.addEventListener("dragover", handleDragOver, true)
-		dom.addEventListener("dragleave", handleDragLeave, true)
 		dom.addEventListener("drop", handleDrop, true)
 		return () => {
 			dom.removeEventListener("dragover", handleDragOver, true)
-			dom.removeEventListener("dragleave", handleDragLeave, true)
 			dom.removeEventListener("drop", handleDrop, true)
 		}
 	}, [view])

--- a/src/editor/editor.tsx
+++ b/src/editor/editor.tsx
@@ -15,6 +15,7 @@ import {
 	keymap,
 	placeholder as placeholderExt,
 	highlightActiveLine,
+	dropCursor,
 } from "@codemirror/view"
 import {
 	deleteMarkupBackward,
@@ -445,6 +446,7 @@ function MarkdownEditor(
 			}),
 			editorExtensions,
 			highlightActiveLine(),
+			dropCursor(),
 			EditorView.lineWrapping,
 			EditorView.updateListener.of(update => {
 				if (update.docChanged) {

--- a/src/editor/editor.tsx
+++ b/src/editor/editor.tsx
@@ -237,6 +237,7 @@ function MarkdownEditor(
 	let dataRef = useRef({ assets, documents })
 	let autoSortRef = useRef(autoSortTasks ?? false)
 	let uploadImageRef = useRef(onUploadImage)
+	let activeDropsRef = useRef<Set<{ pos: number }>>(new Set())
 
 	useEffect(() => {
 		callbacksRef.current = { onChange, onCursorChange, onFocus, onBlur }
@@ -446,8 +447,16 @@ function MarkdownEditor(
 			highlightActiveLine(),
 			EditorView.lineWrapping,
 			EditorView.updateListener.of(update => {
-				if (update.docChanged && callbacksRef.current.onChange) {
-					callbacksRef.current.onChange(update.state.doc.toString())
+				if (update.docChanged) {
+					if (callbacksRef.current.onChange) {
+						callbacksRef.current.onChange(update.state.doc.toString())
+					}
+					// Map drop targets through any concurrent transaction so
+					// images dropped while another upload is awaiting still
+					// land at the intended position.
+					for (let drop of activeDropsRef.current) {
+						drop.pos = update.changes.mapPos(drop.pos, 1)
+					}
 				}
 				if (update.selectionSet && callbacksRef.current.onCursorChange) {
 					let { from, to } = update.state.selection.main
@@ -544,24 +553,29 @@ function MarkdownEditor(
 			let dropPos =
 				view.posAtCoords({ x: event.clientX, y: event.clientY }) ??
 				view.state.doc.length
+			let drop = { pos: dropPos }
+			activeDropsRef.current.add(drop)
 
 			void (async () => {
-				let pos = dropPos
-				for (let file of images) {
-					try {
-						let result = await upload(file)
-						if (!view.contentDOM.isConnected) return
-						let text = `![${result.name}](asset:${result.id})`
-						pos = Math.min(pos, view.state.doc.length)
-						view.dispatch({
-							changes: { from: pos, insert: text },
-							selection: { anchor: pos + text.length },
-						})
-						pos = view.state.selection.main.head
-					} catch (err) {
-						console.error("Image upload failed:", err)
-						toast.error(`Failed to upload ${file.name}`)
+				try {
+					for (let file of images) {
+						try {
+							let result = await upload(file)
+							if (!view.contentDOM.isConnected) return
+							let text = `![${result.name}](asset:${result.id})`
+							let docLength = view.state.doc.length
+							let pos = Math.max(0, Math.min(drop.pos, docLength))
+							view.dispatch({
+								changes: { from: pos, insert: text },
+								selection: { anchor: pos + text.length },
+							})
+						} catch (err) {
+							console.error("Image upload failed:", err)
+							toast.error(`Failed to upload ${file.name}`)
+						}
 					}
+				} finally {
+					activeDropsRef.current.delete(drop)
 				}
 			})()
 		}

--- a/src/editor/editor.tsx
+++ b/src/editor/editor.tsx
@@ -1,6 +1,7 @@
 import { useImperativeHandle, useEffect, useRef, useState } from "react"
 import { diff } from "fast-myers-diff"
 import { ImageOff } from "lucide-react"
+import { toast } from "sonner"
 import { useDocTitles } from "@/lib/doc-resolver"
 import { parseWikiLinks } from "./wikilink-parser"
 import {
@@ -527,36 +528,51 @@ function MarkdownEditor(
 		function handleDrop(event: DragEvent) {
 			let files = event.dataTransfer?.files
 			if (!files || files.length === 0) return
+
+			// Always preventDefault on file drops so non-image files
+			// (PDFs, videos, etc) don't fall through to file:// navigation.
+			event.preventDefault()
+			event.stopPropagation()
+
+			if (!view || view.state.readOnly) return
+			let upload = uploadImageRef.current
+			if (!upload) return
+
 			let images = Array.from(files).filter(f => f.type.startsWith("image/"))
 			if (images.length === 0) return
 
-			event.preventDefault()
-			let upload = uploadImageRef.current
-			if (!upload || !view) return
-
 			let dropPos =
 				view.posAtCoords({ x: event.clientX, y: event.clientY }) ??
-				view.state.selection.main.head
+				view.state.doc.length
 
 			void (async () => {
 				let pos = dropPos
 				for (let file of images) {
-					let result = await upload(file)
-					let text = `![${result.name}](asset:${result.id})`
-					view.dispatch({
-						changes: { from: pos, insert: text },
-						selection: { anchor: pos + text.length },
-					})
-					pos += text.length
+					try {
+						let result = await upload(file)
+						if (!view.contentDOM.isConnected) return
+						let text = `![${result.name}](asset:${result.id})`
+						pos = Math.min(pos, view.state.doc.length)
+						view.dispatch({
+							changes: { from: pos, insert: text },
+							selection: { anchor: pos + text.length },
+						})
+						pos = view.state.selection.main.head
+					} catch (err) {
+						console.error("Image upload failed:", err)
+						toast.error(`Failed to upload ${file.name}`)
+					}
 				}
 			})()
 		}
 
-		dom.addEventListener("dragover", handleDragOver)
-		dom.addEventListener("drop", handleDrop)
+		// Capture phase so our preventDefault runs before CodeMirror's
+		// own drop handler on .cm-content.
+		dom.addEventListener("dragover", handleDragOver, true)
+		dom.addEventListener("drop", handleDrop, true)
 		return () => {
-			dom.removeEventListener("dragover", handleDragOver)
-			dom.removeEventListener("drop", handleDrop)
+			dom.removeEventListener("dragover", handleDragOver, true)
+			dom.removeEventListener("drop", handleDrop, true)
 		}
 	}, [view])
 

--- a/src/editor/editor.tsx
+++ b/src/editor/editor.tsx
@@ -593,10 +593,7 @@ function MarkdownEditor(
 
 			function insertAtTarget(text: string) {
 				if (!activeView.contentDOM.isConnected) return
-				let pos = Math.max(
-					0,
-					Math.min(target.pos, activeView.state.doc.length),
-				)
+				let pos = Math.max(0, Math.min(target.pos, activeView.state.doc.length))
 				activeView.dispatch({
 					changes: { from: pos, insert: text },
 					selection: { anchor: pos + text.length },

--- a/src/editor/editor.tsx
+++ b/src/editor/editor.tsx
@@ -532,8 +532,39 @@ function MarkdownEditor(
 			return event.dataTransfer?.types.includes("Files") ?? false
 		}
 
+		// CodeMirror's dropCursor observer is attached to .cm-content, so it
+		// never fires when the drag is over .cm-scroller whitespace. Forward
+		// synthetic events on .cm-content so the cursor still shows and clears.
+		function forwardToContentDOM(type: string, event: DragEvent) {
+			if (!view) return
+			view.contentDOM.dispatchEvent(
+				new DragEvent(type, {
+					bubbles: false,
+					cancelable: true,
+					clientX: event.clientX,
+					clientY: event.clientY,
+				}),
+			)
+		}
+
 		function handleDragOver(event: DragEvent) {
-			if (isFileDrag(event)) event.preventDefault()
+			if (!isFileDrag(event)) return
+			event.preventDefault()
+			if (
+				view &&
+				event.target instanceof Node &&
+				!view.contentDOM.contains(event.target)
+			) {
+				forwardToContentDOM("dragover", event)
+			}
+		}
+
+		function handleDragLeave(event: DragEvent) {
+			if (!isFileDrag(event) || !dom) return
+			let related = event.relatedTarget
+			let leaving =
+				!related || (related instanceof Node && !dom.contains(related))
+			if (leaving) forwardToContentDOM("dragend", event)
 		}
 
 		function handleDrop(event: DragEvent) {
@@ -544,6 +575,7 @@ function MarkdownEditor(
 			// (PDFs, videos, etc) don't fall through to file:// navigation.
 			event.preventDefault()
 			event.stopPropagation()
+			forwardToContentDOM("dragend", event)
 
 			if (!view || view.state.readOnly) return
 			let upload = uploadImageRef.current
@@ -585,9 +617,11 @@ function MarkdownEditor(
 		// Capture phase so our preventDefault runs before CodeMirror's
 		// own drop handler on .cm-content.
 		dom.addEventListener("dragover", handleDragOver, true)
+		dom.addEventListener("dragleave", handleDragLeave, true)
 		dom.addEventListener("drop", handleDrop, true)
 		return () => {
 			dom.removeEventListener("dragover", handleDragOver, true)
+			dom.removeEventListener("dragleave", handleDragLeave, true)
 			dom.removeEventListener("drop", handleDrop, true)
 		}
 	}, [view])

--- a/src/editor/file-drop-cursor.ts
+++ b/src/editor/file-drop-cursor.ts
@@ -1,0 +1,106 @@
+import { EditorView, ViewPlugin } from "@codemirror/view"
+import { type Extension } from "@codemirror/state"
+
+export { fileDropCursor }
+
+// Custom drop cursor for file drags. The built-in dropCursor() attaches
+// its observers to .cm-content, so it never fires when the drag is over
+// .cm-scroller whitespace (margins, area below the last line). This plugin
+// attaches listeners directly to view.scrollDOM, which covers the entire
+// editor area.
+let fileDropCursorPlugin = ViewPlugin.fromClass(
+	class {
+		view: EditorView
+		cursor: HTMLElement | null = null
+		pos: number | null = null
+
+		constructor(view: EditorView) {
+			this.view = view
+			view.scrollDOM.addEventListener("dragover", this.onDragOver)
+			view.scrollDOM.addEventListener("dragleave", this.onDragLeave)
+			view.scrollDOM.addEventListener("drop", this.onDrop)
+			view.scrollDOM.addEventListener("dragend", this.onDragEnd)
+		}
+
+		onDragOver = (event: DragEvent) => {
+			if (!event.dataTransfer?.types.includes("Files")) return
+			let pos = this.view.posAtCoords({
+				x: event.clientX,
+				y: event.clientY,
+			})
+			this.setPos(pos ?? this.view.state.doc.length)
+		}
+
+		onDragLeave = (event: DragEvent) => {
+			let related = event.relatedTarget
+			if (related instanceof Node && this.view.scrollDOM.contains(related)) {
+				return
+			}
+			this.setPos(null)
+		}
+
+		onDrop = () => this.setPos(null)
+		onDragEnd = () => this.setPos(null)
+
+		setPos(pos: number | null) {
+			if (pos === this.pos) return
+			this.pos = pos
+			this.view.requestMeasure({
+				read: () => this.measure(),
+				write: rect => this.draw(rect),
+			})
+		}
+
+		measure() {
+			if (this.pos == null) return null
+			let rect = this.view.coordsAtPos(this.pos)
+			if (!rect) return null
+			let outer = this.view.scrollDOM.getBoundingClientRect()
+			return {
+				left: rect.left - outer.left + this.view.scrollDOM.scrollLeft,
+				top: rect.top - outer.top + this.view.scrollDOM.scrollTop,
+				height: rect.bottom - rect.top,
+			}
+		}
+
+		draw(rect: { left: number; top: number; height: number } | null) {
+			if (!rect) {
+				if (this.cursor) {
+					this.cursor.remove()
+					this.cursor = null
+				}
+				return
+			}
+			if (!this.cursor) {
+				this.cursor = document.createElement("div")
+				this.cursor.className = "cm-fileDropCursor"
+				this.view.scrollDOM.appendChild(this.cursor)
+			}
+			this.cursor.style.left = rect.left + "px"
+			this.cursor.style.top = rect.top + "px"
+			this.cursor.style.height = rect.height + "px"
+		}
+
+		destroy() {
+			this.view.scrollDOM.removeEventListener("dragover", this.onDragOver)
+			this.view.scrollDOM.removeEventListener("dragleave", this.onDragLeave)
+			this.view.scrollDOM.removeEventListener("drop", this.onDrop)
+			this.view.scrollDOM.removeEventListener("dragend", this.onDragEnd)
+			if (this.cursor) this.cursor.remove()
+		}
+	},
+)
+
+let fileDropCursorTheme = EditorView.theme({
+	".cm-fileDropCursor": {
+		position: "absolute",
+		borderLeft: "2px solid var(--brand)",
+		marginLeft: "-1px",
+		pointerEvents: "none",
+		zIndex: "10",
+	},
+})
+
+function fileDropCursor(): Extension {
+	return [fileDropCursorPlugin, fileDropCursorTheme]
+}

--- a/src/editor/file-drop-cursor.ts
+++ b/src/editor/file-drop-cursor.ts
@@ -3,11 +3,11 @@ import { type Extension } from "@codemirror/state"
 
 export { fileDropCursor }
 
-// Custom drop cursor for file drags. The built-in dropCursor() attaches
-// its observers to .cm-content, so it never fires when the drag is over
-// .cm-scroller whitespace (margins, area below the last line). This plugin
-// attaches listeners directly to view.scrollDOM, which covers the entire
-// editor area.
+type CursorRect = { left: number; top: number; height: number }
+
+// Built-in dropCursor() binds to .cm-content, so file drags over scroller
+// whitespace (margins, below the last line) never show a caret. We bind
+// to scrollDOM so the cursor tracks across the entire editor area.
 let fileDropCursorPlugin = ViewPlugin.fromClass(
 	class {
 		view: EditorView
@@ -51,7 +51,7 @@ let fileDropCursorPlugin = ViewPlugin.fromClass(
 			})
 		}
 
-		measure() {
+		measure(): CursorRect | null {
 			if (this.pos == null) return null
 			let rect = this.view.coordsAtPos(this.pos)
 			if (!rect) return null
@@ -63,7 +63,7 @@ let fileDropCursorPlugin = ViewPlugin.fromClass(
 			}
 		}
 
-		draw(rect: { left: number; top: number; height: number } | null) {
+		draw(rect: CursorRect | null) {
 			if (!rect) {
 				if (this.cursor) {
 					this.cursor.remove()
@@ -101,6 +101,4 @@ let fileDropCursorTheme = EditorView.theme({
 	},
 })
 
-function fileDropCursor(): Extension {
-	return [fileDropCursorPlugin, fileDropCursorTheme]
-}
+let fileDropCursor: Extension = [fileDropCursorPlugin, fileDropCursorTheme]

--- a/src/editor/theme.ts
+++ b/src/editor/theme.ts
@@ -52,6 +52,9 @@ let editorTheme: Extension = EditorView.theme({
 	".cm-activeLine": {
 		backgroundColor: "var(--editor-active-line-bg, transparent)",
 	},
+	".cm-dropCursor": {
+		borderLeftColor: "var(--brand)",
+	},
 	".cm-gutters": {
 		backgroundColor: "var(--editor-background, #fafaf8)",
 		color: "var(--editor-muted, #999)",

--- a/src/editor/theme.ts
+++ b/src/editor/theme.ts
@@ -52,9 +52,6 @@ let editorTheme: Extension = EditorView.theme({
 	".cm-activeLine": {
 		backgroundColor: "var(--editor-active-line-bg, transparent)",
 	},
-	".cm-dropCursor": {
-		borderLeftColor: "var(--brand)",
-	},
 	".cm-gutters": {
 		backgroundColor: "var(--editor-background, #fafaf8)",
 		color: "var(--editor-muted, #999)",


### PR DESCRIPTION
## Summary

Dropping an image on the editor used to navigate the browser to the file's `file://` URL because no drop handlers were wired up. This PR makes the editor accept image and video drops anywhere in its area, upload via the existing `onUploadImage` / `onUploadVideo` flows, and insert `![name](asset:id)` markdown at the drop position. Mirrors what the sidebar's drop zone already supports.

## Test plan

- [ ] Drop a single image onto the editor text area — markdown inserts at the drop position
- [ ] Drop on the empty whitespace below the last line — markdown inserts at end of doc
- [ ] Drop multiple images at once — they stack at the drop position in completion order
- [ ] Drop a video — progress dialog appears, markdown inserts when upload completes
- [ ] Cancel a video upload mid-flight — no markdown inserted, no error toast
- [ ] Drop a mix of images and videos — all process; videos run sequentially after images
- [ ] Drop a video on a browser that can't encode video (`canUploadVideo === false`) — silently ignored
- [ ] Drop a non-supported file (PDF) — silently ignored, no `file://` navigation
- [ ] Drop on a read-only doc — nothing happens