### PR TITLE
Show whiteboard viewers

### DIFF
--- a/src/app/features/assets/lib/schema.ts
+++ b/src/app/features/assets/lib/schema.ts
@@ -1,6 +1,13 @@
 import { co, z } from "jazz-tools"
 
-export { ImageAsset, VideoAsset, TldrawRevision, TldrawAsset, Asset }
+export {
+	ImageAsset,
+	VideoAsset,
+	TldrawRevision,
+	WhiteboardPresenceFeed,
+	TldrawAsset,
+	Asset,
+}
 
 let ImageAsset = co.map({
 	type: z.literal("image"),
@@ -25,11 +32,18 @@ let TldrawRevision = co.map({
 	createdAt: z.date(),
 })
 
+let WhiteboardPresenceFeed = co.feed(
+	z.object({
+		open: z.boolean(),
+	}),
+)
+
 let TldrawAsset = co.map({
 	version: z.literal(1).optional(),
 	type: z.literal("tldraw"),
 	name: z.string(),
 	revision: TldrawRevision,
+	presence: co.optional(WhiteboardPresenceFeed),
 	createdAt: z.date(),
 })
 

--- a/src/app/features/assets/lib/tldraw.ts
+++ b/src/app/features/assets/lib/tldraw.ts
@@ -1,7 +1,12 @@
 import { co, type Group } from "jazz-tools"
 import { createImage } from "jazz-tools/media"
 import { z } from "zod"
-import { Asset, TldrawAsset, TldrawRevision } from "./schema"
+import {
+	Asset,
+	TldrawAsset,
+	TldrawRevision,
+	WhiteboardPresenceFeed,
+} from "./schema"
 import { Document } from "@/app/features/documents/lib/schema"
 import { syncDocumentMetadata } from "@/app/features/documents/lib/metadata"
 
@@ -85,6 +90,7 @@ function createTldrawAssetFromRevision(
 			type: "tldraw",
 			name,
 			revision,
+			presence: WhiteboardPresenceFeed.create([], { owner }),
 			createdAt,
 		},
 		owner,

--- a/src/app/features/assets/widgets/tldraw-editor-dialog.tsx
+++ b/src/app/features/assets/widgets/tldraw-editor-dialog.tsx
@@ -22,6 +22,7 @@ import { ConfirmDialog } from "@/app/components/ui/confirm-dialog"
 import { T, useIntl } from "@/shared/intl/setup"
 import type { TldrawSave } from "../lib/tldraw"
 import type { TldrawCanvasHandle } from "./tldraw-canvas"
+import { WhiteboardPresence } from "./whiteboard-presence"
 
 export { TldrawEditorDialog }
 
@@ -33,6 +34,7 @@ let LazyTldrawCanvas = lazy(() =>
 
 interface TldrawEditorDialogProps {
 	open: boolean
+	assetId?: string
 	name: string
 	initialJson?: string
 	mode: "create" | "edit" | "import"
@@ -42,6 +44,7 @@ interface TldrawEditorDialogProps {
 
 function TldrawEditorDialog({
 	open,
+	assetId,
 	name,
 	initialJson,
 	mode,
@@ -111,13 +114,16 @@ function TldrawEditorDialog({
 					className="inset-0 top-0 left-0 isolate !flex h-[100dvh] max-w-none translate-x-0 flex-col gap-0 rounded-none border-0 p-0 ring-0 sm:top-0 sm:max-w-none sm:translate-y-0"
 				>
 					<DialogHeader className="border-border bg-background z-10 flex h-[calc(3.5rem+env(safe-area-inset-top))] shrink-0 flex-row items-end justify-between gap-3 border-b px-2 pt-[env(safe-area-inset-top)] pb-1.5 sm:h-14 sm:items-center sm:px-3 sm:pt-0 sm:pb-0">
-						<div className="min-w-0 px-1">
-							<DialogTitle className="truncate text-sm font-medium sm:text-base">
-								{name}
-							</DialogTitle>
-							<DialogDescription className="sr-only">
-								{t("assets.whiteboardEditorDescription")}
-							</DialogDescription>
+						<div className="flex min-w-0 flex-1 items-center gap-2 px-1">
+							<div className="min-w-0">
+								<DialogTitle className="truncate text-sm font-medium sm:text-base">
+									{name}
+								</DialogTitle>
+								<DialogDescription className="sr-only">
+									{t("assets.whiteboardEditorDescription")}
+								</DialogDescription>
+							</div>
+							{assetId && <WhiteboardPresence assetId={assetId} />}
 						</div>
 						<div className="flex shrink-0 items-center gap-1.5">
 							<Button

--- a/src/app/features/assets/widgets/use-tldraw-editor.tsx
+++ b/src/app/features/assets/widgets/use-tldraw-editor.tsx
@@ -109,6 +109,7 @@ function useTldrawEditor({
 	let dialog = editor ? (
 		<TldrawEditorDialog
 			open={true}
+			assetId={editor.assetId}
 			name={editor.name}
 			initialJson={editor.initialJson}
 			mode={editor.mode}

--- a/src/app/features/assets/widgets/whiteboard-presence.test.ts
+++ b/src/app/features/assets/widgets/whiteboard-presence.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+import { countActiveWhiteboardSessions } from "./whiteboard-presence"
+
+describe("countActiveWhiteboardSessions", () => {
+	it("counts every other active session", () => {
+		let now = Date.now()
+		expect(
+			countActiveWhiteboardSessions(
+				{
+					current: { value: { open: true }, madeAt: new Date(now) },
+					otherDevice: { value: { open: true }, madeAt: new Date(now) },
+					otherPerson: { value: { open: true }, madeAt: new Date(now) },
+				},
+				"current",
+				now,
+			),
+		).toBe(2)
+	})
+
+	it("ignores closed and expired sessions", () => {
+		let now = Date.now()
+		expect(
+			countActiveWhiteboardSessions(
+				{
+					closed: { value: { open: false }, madeAt: new Date(now) },
+					expired: {
+						value: { open: true },
+						madeAt: new Date(now - 15_001),
+					},
+				},
+				null,
+				now,
+			),
+		).toBe(0)
+	})
+})

--- a/src/app/features/assets/widgets/whiteboard-presence.tsx
+++ b/src/app/features/assets/widgets/whiteboard-presence.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from "react"
+import { Group } from "jazz-tools"
+import { useAccount, useCoState } from "jazz-tools/react"
+import { Users } from "lucide-react"
+import { UserAccount } from "@/schema"
+import { useIntl } from "@/shared/intl/setup"
+import { TldrawAsset, WhiteboardPresenceFeed } from "../lib/schema"
+
+export { WhiteboardPresence, countActiveWhiteboardSessions }
+
+let HEARTBEAT_MS = 5_000
+let STALE_AFTER_MS = 15_000
+
+type PresenceSessions = Record<
+	string,
+	| {
+			value: { open: boolean } | null
+			madeAt: Date
+	  }
+	| undefined
+>
+
+function WhiteboardPresence({ assetId }: { assetId: string }) {
+	let t = useIntl()
+	let me = useAccount(UserAccount)
+	let asset = useCoState(TldrawAsset, assetId, {
+		resolve: { presence: true },
+	})
+	let [now, setNow] = useState(() => Date.now())
+	let mySessionId = me.$isLoaded ? (me.$jazz.sessionID ?? null) : null
+	let presence = asset?.$isLoaded ? asset.presence : undefined
+
+	useEffect(() => {
+		if (!mySessionId) return
+		let activePresence: typeof presence
+		let heartbeat: number | undefined
+		let stopped = false
+
+		function publishOpen() {
+			if (!activePresence?.$isLoaded) return
+			activePresence.$jazz.push({ open: true })
+			setNow(Date.now())
+		}
+
+		function publishClosed() {
+			if (activePresence?.$isLoaded) activePresence.$jazz.push({ open: false })
+		}
+
+		async function startHeartbeat() {
+			let loaded = await TldrawAsset.load(assetId, {
+				resolve: { presence: true },
+			})
+			if (!loaded.$isLoaded || stopped) return
+
+			activePresence = loaded.presence
+			if (!activePresence) {
+				let owner = loaded.$jazz.owner
+				if (!(owner instanceof Group)) return
+				activePresence = WhiteboardPresenceFeed.create([], { owner })
+				loaded.$jazz.set("presence", activePresence)
+			}
+
+			publishOpen()
+			heartbeat = window.setInterval(publishOpen, HEARTBEAT_MS)
+		}
+
+		void startHeartbeat()
+		window.addEventListener("pagehide", publishClosed)
+		return () => {
+			stopped = true
+			if (heartbeat !== undefined) window.clearInterval(heartbeat)
+			window.removeEventListener("pagehide", publishClosed)
+			publishClosed()
+		}
+	}, [assetId, mySessionId])
+
+	let count = countActiveWhiteboardSessions(
+		presence?.$isLoaded ? presence.perSession : {},
+		mySessionId,
+		now,
+	)
+	if (count === 0) return null
+
+	let label =
+		count === 1
+			? t("assets.whiteboardPresenceOne")
+			: t("assets.whiteboardPresenceMany", { count: String(count) })
+
+	return (
+		<div
+			role="status"
+			aria-live="polite"
+			className="bg-muted text-muted-foreground flex shrink-0 items-center gap-1.5 rounded-full px-2 py-1 text-xs whitespace-nowrap"
+		>
+			<Users aria-hidden="true" className="size-3.5" />
+			<span>{label}</span>
+		</div>
+	)
+}
+
+function countActiveWhiteboardSessions(
+	sessions: PresenceSessions,
+	currentSessionId: string | null,
+	now: number,
+) {
+	return Object.entries(sessions).filter(([sessionId, entry]) => {
+		if (sessionId === currentSessionId || !entry?.value?.open) return false
+		return now - entry.madeAt.getTime() <= STALE_AFTER_MS
+	}).length
+}

--- a/src/shared/intl/messages.common.ts
+++ b/src/shared/intl/messages.common.ts
@@ -41,6 +41,8 @@ let baseCommonMessages = messages({
 	"assets.whiteboardSaved": "Whiteboard saved",
 	"assets.whiteboardAdded": "Whiteboard added",
 	"assets.whiteboardSaveFailed": "Could not save the whiteboard",
+	"assets.whiteboardPresenceOne": "1 other viewing",
+	"assets.whiteboardPresenceMany": "{$count} others viewing",
 	"assets.discardWhiteboardTitle": "Discard whiteboard changes?",
 	"assets.discardWhiteboardDescription":
 		"Your changes since opening the whiteboard will be lost.",
@@ -201,6 +203,8 @@ let deCommonMessages = translate(baseCommonMessages, {
 	"assets.whiteboardAdded": "Whiteboard hinzugefügt",
 	"assets.whiteboardSaveFailed":
 		"Das Whiteboard konnte nicht gespeichert werden",
+	"assets.whiteboardPresenceOne": "1 weitere Sitzung",
+	"assets.whiteboardPresenceMany": "{$count} weitere Sitzungen",
 	"assets.discardWhiteboardTitle": "Whiteboard-Änderungen verwerfen?",
 	"assets.discardWhiteboardDescription":
 		"Deine Änderungen seit dem Öffnen des Whiteboards gehen verloren.",


### PR DESCRIPTION
## What changed

- add asset-scoped Jazz session presence for open whiteboards
- show a visible, accessible viewer count in the whiteboard header
- count the same account on another device/session while excluding the current session
- expire abruptly closed sessions automatically and support existing whiteboards lazily
- add English and German labels plus presence-count tests

## Why

Concurrent whiteboard editors can overwrite each other's saved revisions. Showing who else has the board open gives users an immediate warning before editing or saving.

## Validation

- `bun run check:types`
- focused whiteboard tests: 9 passed
- full suite: 709 passed initially; 3 load-related timing failures all passed on isolated rerun (27/27)
- targeted ESLint and Prettier checks
- agent-browser QA with two anonymous tabs sharing one identity: both showed `1 other viewing`

Browser QA also exposed a heartbeat render loop in the initial implementation; the final lifecycle loads the feed once per editor session and remains responsive.
